### PR TITLE
Fixes #35.  Creates two Service Registration Storage Providers

### DIFF
--- a/controllers/admin/index.js
+++ b/controllers/admin/index.js
@@ -17,13 +17,17 @@
 
 /**
  * Interface for the admin dashboard
+ * @class AdminIndexController
+ * @constructor
  */
-
 function AdminIndexController(){}
 
 //inheritance
 util.inherits(AdminIndexController, pb.BaseController);
 
+/**
+ * @see BaseController#render
+ */
 AdminIndexController.prototype.render = function(cb) {
 	var self = this;
 
@@ -62,6 +66,16 @@ AdminIndexController.prototype.render = function(cb) {
 	});
 };
 
+/**
+ * Gather all necessary data for rendering the dashboard.
+ * <ul>
+ * <li>Article count</li>
+ * <li>Page Count</li>
+ * <li>Cluster Status</li>
+ * </ul>
+ * @method gatherData
+ * @param {Function} cb A callback that provides two parameters: cb(Error, Object)
+ */
 AdminIndexController.prototype.gatherData = function(cb) {
 	var tasks = {
 
@@ -80,16 +94,7 @@ AdminIndexController.prototype.gatherData = function(cb) {
 		//cluster status
 		clusterStatus: function(callback) {
 			var service = new pb.ServerRegistration();
-			service.getClusterStatus(function(err, clusterObj) {
-				var cluster = [];
-				if (clusterObj) {
-					for (var prop in clusterObj) {
-						try {
-							cluster.push(JSON.parse(clusterObj[prop]));
-						}
-						catch(e){}
-					}
-				}
+			service.getClusterStatus(function(err, cluster) {
 				callback(err, cluster);
 			});
 		}

--- a/controllers/api/admin/system/cluster_api.js
+++ b/controllers/api/admin/system/cluster_api.js
@@ -18,8 +18,9 @@
 /**
  * Controller to properly route and handle remote calls to interact with
  * the cluster
+ * @class ClusterApiController
+ * @constructor
  */
-
 function ClusterApiController() {};
 
 //dependencies
@@ -37,14 +38,23 @@ var ACTIONS = {
 
 /**
  * Provides the hash of all actions supported by this controller
+ * @method getActions
+ * @return {Object} Hash of acceptable actions
  */
 ClusterApiController.prototype.getActions = function() {
 	return ACTIONS;
 };
 
+/**
+ * Causes the service registration storage to flush all status updates.  An API 
+ * object is returned to the client that specifies the correct amount of time to 
+ * wait before the service registry is updated again by all nodes.
+ * @method refresh
+ * @param {Function} cb
+ */
 ClusterApiController.prototype.refresh = function(cb) {
     pb.ServerRegistration.flush(function(err, result) {
-        var content = BaseController.apiResponse(BaseController.API_SUCCESS, '', {wait: pb.config.registry.update_interval});
+        var content = BaseController.apiResponse(BaseController.API_SUCCESS, 'The wait time in seconds', {wait: pb.config.registry.update_interval});
         cb({content: content});
     });
 };

--- a/include/config.js
+++ b/include/config.js
@@ -36,43 +36,43 @@ global.LOG_DIR   = path.join(DOCUMENT_ROOT, 'log');
 global.LOG_FILE  = path.join(LOG_DIR, 'pencilblue.log');
 
 var config = {
-    
+
     //The name of the site.
 	siteName: 'pencilblue',
-    
-    //The root of the site.  This host part should ALWAYS match the value of 
+
+    //The root of the site.  This host part should ALWAYS match the value of
     //the siteIP
 	siteRoot: 'http://localhost:8080',
-    
-    //The hostname or IP address represented by the entire site.  Should match 
+
+    //The hostname or IP address represented by the entire site.  Should match
     //your domain name if in production use.
 	siteIP:   'localhost',
-    
-    //The primary port to listen for traffic on. 
+
+    //The primary port to listen for traffic on.
 	sitePort: 8080,
-    
+
     //the absolute file path to the directory where installation lives
 	docRoot:  DOCUMENT_ROOT,
-    
-    //provides a configuration for connecting to persistent storage.  The 
+
+    //provides a configuration for connecting to persistent storage.  The
     //default configuration is meant for mongodb.
 	db: {
         type:'mongo',
 		servers: [
           'mongodb://127.0.0.1:27017/'
         ],
-        
+
         //the name of the default DB for the system
         name: 'pencil_blue',
-        
+
         //http://docs.mongodb.org/manual/core/write-concern/
         writeConern: 1,
-        
-        //PB provides the ability to log queries.  This is handy during 
-        //development to see how many trips to the DB a single request is 
+
+        //PB provides the ability to log queries.  This is handy during
+        //development to see how many trips to the DB a single request is
         //making.  The queries log at level "info".
         query_logging: false,
-        
+
         //http://mongodb.github.io/node-mongodb-native/api-generated/db.html#authenticate
         authentication: {
             un: null,
@@ -84,9 +84,9 @@ var config = {
             }
         }
 	},
-    
-    //PB supports redis as a caching layer out of the box.  For development 
-    //purposes the "fake-redis" module can be used by setting the fake property 
+
+    //PB supports redis as a caching layer out of the box.  For development
+    //purposes the "fake-redis" module can be used by setting the fake property
     //to true.
 	cache: {
 		fake: true,
@@ -94,18 +94,18 @@ var config = {
 		port: 6379,
         //auth_pass: "password here"
 	},
-    
-    //PB supports two session stores out of the box: mongo & redis.  The 
+
+    //PB supports two session stores out of the box: mongo & redis.  The
     //timeout value is in ms.
 	session: {
 		storage: "redis",
 		timeout: 600000
 	},
-    
+
     //The global log level: silly, debug, info, warn, error
 	log_level: LOG_LEVEL,
-    
-    //The list of supported locales along with the location of the localization 
+
+    //The list of supported locales along with the location of the localization
     //keys.
 	locales: {
 		supported: [
@@ -115,26 +115,26 @@ var config = {
         	}
         ]
 	},
-    
-    //System settings always have the persistent storage layer on.  Optionally, 
-    //the cache and/or memory can be used.  It is not recommended to use memory 
-    //unless you are developing locally with a single worker.  Memory is not 
+
+    //System settings always have the persistent storage layer on.  Optionally,
+    //the cache and/or memory can be used.  It is not recommended to use memory
+    //unless you are developing locally with a single worker.  Memory is not
     //synced across cluster workers so be careful if this option is set to true.
 	settings: {
 		use_memory: true,
 		use_cache: false
 	},
-    
-    //The template engine can take advantage of caching so that they are not 
-    //retrieved and compiled from disk on each request.  In a development 
-    //environment it is ok because you will want to see the changes you make 
-    //after each tweak.  
+
+    //The template engine can take advantage of caching so that they are not
+    //retrieved and compiled from disk on each request.  In a development
+    //environment it is ok because you will want to see the changes you make
+    //after each tweak.
 	templates: {
 		use_memory: true,
 		use_cache: false
 	},
-    
-    //Plugins can also take advantage of the caching.  This prevents a DB call 
+
+    //Plugins can also take advantage of the caching.  This prevents a DB call
     //to lookup active plugins and their settings.
 	plugins: {
 		caching: {
@@ -142,38 +142,42 @@ var config = {
 			use_cache: false,
 		}
 	},
-    
-    //PB provides a process registry.  It utilizes the cache to register 
-    //properties about itself that are available via API or in the admin 
-    //console.  This makes it easy to assist in monitoring your cluster and 
-    //processes in production or development.  The update interval specifies 
-    //how many ms to wait before updating the registry with fresh data about 
-    //itself.  The key specifies what the base of the cache key looks like.
+
+    //PB provides a process registry.  It utilizes the cache to register
+    //properties about itself that are available via API or in the admin
+    //console.  This makes it easy to assist in monitoring your cluster and
+    //processes in production or development.  The type value can be one of
+    //three values: 'redis', 'mongo' or an absolute path that implements the
+    //functions necessary to be a registration storage provider.The update
+    //interval specifies how many ms to wait before updating the registry with
+    //fresh data about itself.  The key specifies what the base of the cache
+    //key looks like.
 	registry: {
 		enabled: true,
+        type: "redis",
 		update_interval: 10000,
 		key: 'server_registry'
 	},
-    
-    //PB aims to help developers scale.  The system can take advantage of 
-    //Node's cluster module to scale across the system cores. In order to 
-    //protect against repeated catastrophic failures the system allows for 
-    //"fatal_error_count" errors to occur outside of "fatal_error_timeout" secs.  
-    //If the maximum number of failures occur inside of the allowed timeframe 
+
+    //PB aims to help developers scale.  The system can take advantage of
+    //Node's cluster module to scale across the system cores. In order to
+    //protect against repeated catastrophic failures the system allows for
+    //"fatal_error_count" errors to occur outside of "fatal_error_timeout" secs.
+    //If the maximum number of failures occur inside of the allowed timeframe
     //the master process and all the worker children will shutdown.
     cluster: {
         fatal_error_timeout: 2000,
         fatal_error_count: 5,
         workers: 1
     },
-    
-    //PB supports two methods of handling SSL.  Standard point to a cert as 
-    //described by the options below and SSL termination and the use of the 
-    //"X-FORWARDED-PROTO" header.  Node does not gracefully handle the redirect 
-    //of HTTP traffic to HTTPS.  PB handles this for you in what we call the 
-    //handoff.  PB will start a second http server listening on the 
-    //"handoff_port".  When traffic is received it will be redirected to the 
-    //URL of the form "siteRoot+[URL PATH]".  The port will only show if 
+
+    //PB supports two methods of handling SSL.  Standard point to a cert as
+    //described by the options below and SSL termination and the use of the
+    //"X-FORWARDED-PROTO" header.  Node does not gracefully handle the redirect
+    //of HTTP traffic to HTTPS.  PB handles this for you in what we call the
+    //handoff.  PB will start a second http server listening on the
+    //"handoff_port".  When traffic is received it will be redirected to the
+    //URL of the form "siteRoot+[URL PATH]".  The port will only show if
     //specified by the "use_handoff_port_in_redirect" property.
     server: {
         ssl: {

--- a/include/dao/cache.js
+++ b/include/dao/cache.js
@@ -38,10 +38,19 @@ CacheFactory.getInstance = function() {
         return CLIENT;
     }
 
+    CLIENT = CacheFactory.createInstance();
+    return CLIENT;
+};
+
+/**
+ *
+ *
+ *
+ */
+CacheFactory.createInstance = function() {
     var moduleAtPlay = pb.config.cache.fake ? "fakeredis" : "redis";
     var Redis        = require(moduleAtPlay);
-    CLIENT           = Redis.createClient(pb.config.cache.port, pb.config.cache.host, pb.config.cache);
-    return CLIENT;
+    return Redis.createClient(pb.config.cache.port, pb.config.cache.host, pb.config.cache);
 };
 
 /**

--- a/include/dao/dao.js
+++ b/include/dao/dao.js
@@ -21,6 +21,7 @@
  * @module Database
  * @class DAO
  * @constructor
+ * @param {String} [dbName] Will default to the config.db.name DB when not provided.
  * @main Database
  */
 function DAO(dbName){
@@ -175,9 +176,9 @@ DAO.prototype.unique = function(collection, where, exclusionId, cb) {
  * @param  {Object} [where]    Key value pair object
  * @param  {Object} [select]   Selection type object
  * @param  {Object} [orderBy]  Order by object (MongoDB syntax)
- * @param  {Number} [limit]    Number of documents to retrieve
- * @param  {Number} [offset]   Start index of retrieval
- * @return {Object}            A promise object
+ * @param  {Integer} [limit]    Number of documents to retrieve
+ * @param  {Integer} [offset]   Start index of retrieval
+ * @return {Promise}            A promise object
  */
 DAO.prototype.query = function(entityType, where, select, orderBy, limit, offset){
 
@@ -200,6 +201,19 @@ DAO.prototype.query = function(entityType, where, select, orderBy, limit, offset
 	return promise;
 };
 
+/**
+ * The actual implementation for querying.  The function does not do the same
+ * type checking as the wrapper function "query".  This funciton is responsible
+ * for doing the heavy lifting and returning the result back to the calling intity.
+ * @protected
+ * @method _doQuery
+ * @param {String} entityType The collection to query
+ * @param {Object} [where={}] The where clause
+ * @param {Object} [select={}] The fields to project
+ * @param {Array} [orderBy] The ordering
+ * @param {Integer} [limit] The maximum number of results to return
+ * @param {Integer} [offset] The number of results to skip before returning results.
+ */
 DAO.prototype._doQuery = function(entityType, where, select, orderBy, limit, offset) {
 	//verify a collection was provided
 	if (typeof entityType === 'undefined') {
@@ -241,7 +255,7 @@ DAO.prototype._doQuery = function(entityType, where, select, orderBy, limit, off
  *
  * @method insert
  * @param  {Object} dbObject The database object to persist
- * @return {Object}          Promise object
+ * @return {Promise}          Promise object
  */
 DAO.prototype.insert = function(dbObject) {
 	var promise = new Promise();
@@ -258,7 +272,7 @@ DAO.prototype.insert = function(dbObject) {
  *
  * @method update
  * @param  {Object} dbObj The new document object
- * @return {Object}          Promise object
+ * @return {Promise}          Promise object
  */
 DAO.prototype.update = function(dbObj) {
 
@@ -277,7 +291,7 @@ DAO.prototype.update = function(dbObj) {
  * @method deleteById
  * @param {String} oid        The Id of the object to remove
  * @param {String} collection The collection the object is in
- * @return {Object}           Promise object
+ * @return {Promise}           Promise object
  */
 DAO.prototype.deleteById = function(oid, collection){
 	if (typeof oid === 'undefined') {
@@ -318,8 +332,52 @@ DAO.prototype.deleteMatching = function(where, collection){
 };
 
 /**
+ * Sends a command to the DB.
+ * http://mongodb.github.io/node-mongodb-native/api-generated/db.html#command
+ * @method command
+ * @param {Object} The command to execute
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+DAO.prototype.command = function(command, cb) {
+    if (!pb.utils.isObject(command)) {
+        cb(new Error('The command must be a valid object'));
+        return;
+    }
+    pb.dbm[this.dbName].command(command, cb);
+};
+
+/**
+ * Attempts to create an index.  If the collection already exists then the
+ * operation is skipped.
+ * http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#ensureindex
+ * @method ensureIndex
+ * @param {Object} procedure The objects containing the necessary parameters
+ * and options to create the index.
+ *  @param {String} procedure.collection The collection to build an index for
+ *  @param {Object} procedure.spec An object that specifies one or more fields
+ * and sort direction for the index.
+ *  @param {Object} [procedure.options={}] An optional parameter that can
+ * specify the options for the index.
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+DAO.prototype.ensureIndex = function(procedure, cb) {
+    if (!util.isObject(procedure)) {
+        cb(new Error('A valid procedure object is required in order to execute the indexing operation'));
+        return;
+    }
+
+    //extract needed values
+    var collection = procedure.collection;
+    var spec       = procedure.spec;
+    var options    = procedure.options || {};
+
+    //create the index (if doesn't exist)
+    pb.dbm[this.dbName].collection(collection).ensureIndex(spec, options, cb);
+};
+
+/**
  * Creates a basic where clause based on the specified Id
- *
+ * @static
  * @method getIDWhere
  * @param {String} oid Object Id String
  * @return {Object}    Where clause
@@ -330,6 +388,15 @@ DAO.getIDWhere = function(oid){
 	};
 };
 
+/**
+ * Creates a where clause that equates to select where [idProp] is in the
+ * specified array of values.
+ * @static
+ * @method getIDInWhere
+ * @param {Array} objArray The array of acceptable values
+ * @param {String} The property that holds a referenced ID value
+ * @return {Object} Where clause
+ */
 DAO.getIDInWhere = function(objArray, idProp) {
 	var idArray = [];
     for(var i = 0; i < objArray.length; i++) {
@@ -351,7 +418,7 @@ DAO.getIDInWhere = function(objArray, idProp) {
 
 /**
  * Creates a basic where clause based on not equalling the specified Id
- *
+ * @static
  * @method getNotIDWhere
  * @param {String} oid Object Id String
  * @return {Object}    Where clause
@@ -362,13 +429,20 @@ DAO.getNotIDWhere = function(oid) {
 	};
 };
 
+/**
+ * Creates a where clause that indicates to select where the '_id' field does
+ * not equal the specified value.
+ * @static
+ * @method getNotIDField
+ * @return {Object} Where clause
+ */
 DAO.getNotIDField = function(oid) {
 	return {$ne: DAO.getObjectID(oid)};
 };
 
 /**
  * Creates an MongoDB ObjectID object
- *
+ * @static
  * @method getObjectID
  * @param {String} oid Object Id String
  * @return {Object}    ObjectID object
@@ -379,7 +453,7 @@ DAO.getObjectID = function(oid) {
 
 /**
  * Updates a DB object with a created time stamp and last modified time stamp.
- *
+ * @static
  * @method updateChangeHistory
  * @param {Object} dbObject Object to update
  */
@@ -397,4 +471,5 @@ DAO.updateChangeHistory = function(dbObject){
 	dbObject.last_modified = now;
 };
 
+//exports
 module.exports = DAO;

--- a/include/requirements.js
+++ b/include/requirements.js
@@ -101,6 +101,11 @@ global.PBError = require(DOCUMENT_ROOT+'/include/error/pb_error.js').PBError;
 pb.Localization = require(DOCUMENT_ROOT+'/include/localization.js').Localization;
 pb.Localization.init();
 
+//server registration
+pb.MongoRegistrationProvider = require(path.join(DOCUMENT_ROOT, '/include/system/registry/mongo_registration_provider.js'));
+pb.RedisRegistrationProvider = require(path.join(DOCUMENT_ROOT, '/include/system/registry/redis_registration_provider.js'));
+pb.ServerRegistration        = require(DOCUMENT_ROOT+'/include/system/server_registration.js');
+
 //Email settings and functions
 pb.EmailService = require(DOCUMENT_ROOT+'/include/email').EmailService;
 pb.email        = new pb.EmailService();
@@ -110,7 +115,6 @@ pb.DocumentCreator    = require(DOCUMENT_ROOT+'/include/model/create_document.js
 pb.content            = require(DOCUMENT_ROOT+'/include/content').ContentService;			        	// Content settings and functions
 pb.js                 = require(DOCUMENT_ROOT+'/include/client_js').ClientJS;							// Client JS
 pb.AdminNavigation    = require(DOCUMENT_ROOT+'/include/admin_navigation').AdminNavigation;			// Admin Navigation
-pb.ServerRegistration = require(DOCUMENT_ROOT+'/include/system/server_registration.js');
 pb.AdminSubnavService = require(DOCUMENT_ROOT+'/include/service/admin/admin_subnav_service.js');
 pb.AnalyticsManager   = require(path.join(DOCUMENT_ROOT, '/include/system/analytics_manager.js'));
 pb.UrlService         = require(DOCUMENT_ROOT+'/include/service/entities/url_service.js');

--- a/include/system/registry/mongo_registration_provider.js
+++ b/include/system/registry/mongo_registration_provider.js
@@ -1,0 +1,161 @@
+/*
+    Copyright (C) 2014  PencilBlue, LLC
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+/**
+ * Implements the necessary functions in order to be able to create and manage
+ * a service registry for PB processes in the cluster.  This provider uses MongoDB
+ * as the storage.  In addition, it leverages MongoDB's TTL collections.  The
+ * reaper for mongo runs every 60 seconds.  It is possible for dead processes to
+ * appear in the status list for up to that magical 60 second threshold.  The
+ * name of the collection used to store all statuses is determined by the
+ * configuration property: "registry.key".
+ * @class MongoRegistrationProvider
+ * @constructor
+ */
+function MongoRegistrationProvider(){}
+
+/**
+ * Retrieves the entire cluster status as an array of status objects.  The '_id'
+ * property uniquely identifies each process/node.
+ * @method get
+ * @param {Function} cb A callback that provides two parameters: cb(Error, Array)
+ */
+MongoRegistrationProvider.prototype.get = function(cb) {
+
+    var dao = new pb.DAO();
+    dao.query(pb.config.registry.key, pb.DAO.ANYWHERE).then(function(statuses) {
+        if (util.isError(statuses)) {
+            cb(statuses);
+            return;
+        }
+
+        cb(null, statuses);
+    });
+};
+
+/**
+ * Updates the status of a single node.
+ * @method set
+ * @param {String} id The unique identifier for the process/node
+ * @param {Object} status The status information
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+MongoRegistrationProvider.prototype.set = function(id, status, cb) {
+    if (!pb.utils.isObject(status)) {
+        cb(new Error('The status parameter must be a valid object'));
+        return;
+    }
+
+    status._id         = id;
+    status.object_type = pb.config.registry.key;
+    var dao = new pb.DAO();
+    dao.update(status).then(function(result) {
+        if (util.isError(result)) {
+            cb(result);
+            return;
+        }
+        cb(null, result);
+    });
+};
+
+/**
+ * Purges all statuses from storage.
+ * @method flush
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+MongoRegistrationProvider.prototype.flush = function(cb) {
+    var dao = new pb.DAO();
+    dao.deleteMatching(pb.DAO.ANYWHERE, pb.config.registry.key).then(function(result) {
+        if (util.isError(result)) {
+            cb(result);
+            return;
+        }
+        cb(null, result);
+    });
+};
+
+/**
+ * This function should only be called once at startup.  It is responsible for
+ * setting up the collection and ensuring that the TTL index is configured
+ * correctly based on the the executing processes configuration.  <b>NOTE:</b>
+ * The collection only supports one TTL value. The last process to startup and
+ * configure the index will win.  Please be careful to ensure that all PB
+ * processes/nodes have the same registry.update_interval value.
+ * @static
+ * @method init
+ * @param {Function} cb A callback that takes two parameters. cb(Error, [RESULT])
+ */
+MongoRegistrationProvider.init = function(cb) {
+
+    //prepare index values
+    var expiry    = Math.floor(pb.config.registry.update_interval / pb.utils.TIME.MILLIS_PER_SEC);
+    var procedure = {
+        collection: pb.config.registry.key,
+        spec: { last_modified: 1 },
+        options: { expireAfterSeconds: expiry }
+    }
+
+    //ensure an index exists.  According to the MongoDB documentation ensure
+    //index cannot modify a TTL value once it is created.  Therefore, we have
+    //to ensure that the index exists and then send the collection modification
+    //command to change the TTL value.
+    var dao = new pb.DAO();
+    dao.ensureIndex(procedure, function(err, result) {
+        pb.log.silly('MongoRegistrationProvider: Attempted to ensure TTL index. RESULT=[%s] ERROR=[%s]', util.inspect(result), err ? err.message : 'NONE');
+
+         var command = {
+            collMod: pb.config.registry.key,
+            index: {
+                keyPattern: {last_modified:1},
+                expireAfterSeconds: expiry
+            }
+        };
+        dao.command(command, function(err, result) {
+            pb.log.silly('MongoRegistrationProvider: Attempted to modify the TTL index. RESULT=[%s] ERROR=[%s]', util.inspect(result), err ? err.message : 'NONE');
+            cb(err, result);
+        });
+    });
+};
+
+/**
+ * Should be called during shutdown.  It is responsible for removing the
+ * process/node from the registry.
+ * @static
+ * @method shutdown
+ * @param {String} id The unique identifier for the node/process
+ * @param {Function} cb A callback that takes two parameters: cb(Error, [RESULT])
+ */
+MongoRegistrationProvider.shutdown = function(id, cb) {
+    if (!id) {
+        pb.log.error('MongoRegistrationProvider: A valid ID is needed in order to properly shutdown');
+        cb(null, false);
+    }
+
+    var dao = new pb.DAO();
+    dao.deleteById(id, pb.config.registry.key).then(function(result) {
+        if (util.isError(result)) {
+            cb(result);
+            return;
+        }
+
+        cb(null, result);
+    });
+};
+
+//exports
+module.exports = MongoRegistrationProvider;

--- a/include/system/registry/redis_registration_provider.js
+++ b/include/system/registry/redis_registration_provider.js
@@ -1,0 +1,182 @@
+/*
+    Copyright (C) 2014  PencilBlue, LLC
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Implements the necessary functions in order to be able to create and manage
+ * a service registry for PB processes in the cluster.  This provider uses Redis
+ * as the storage.  In addition, it leverages Redis's expiry functionality to
+ * expire entries automatically if they have not been touched.  In order to
+ * retrieve all nodes/processes in the cluster the provider must execute
+ * Redis's "keys" function which is an expensive operation.  To lessen the
+ * impact on production systems the provider creates and manages its own Redis
+ * client and switches to DB 2 in order to minimize the number of keys that
+ * need to be scanned since the rest of the PB system leverages DB 0.
+ * @class RedisRegistrationProvider
+ * @constructor
+ */
+function RedisRegistrationProvider(){}
+
+//constants
+/**
+ * The Redis DB used for storage
+ * @private
+ * @property REGISTRY_DB
+ * @type {Integer}
+ */
+var REGISTRY_DB = 2;
+
+/**
+ * The character used to separate the registry key prefix from the unique value
+ * that identifies the process/node.
+ * @private
+ * @property SEP
+ * @type {String}
+ */
+var SEP = '-';
+
+/**
+ * The Redis client used to connect to the service registry
+ * @private
+ * @property CLIENT
+ * @type {Integer}
+ */
+var CLIENT = null;
+
+/**
+ * Retrieves the entire cluster status as an array of status objects.  The '_id'
+ * property uniquely identifies each process/node.
+ * @method get
+ * @param {Function} cb A callback that provides two parameters: cb(Error, Array)
+ */
+RedisRegistrationProvider.prototype.get = function(cb) {
+
+    var pattern = RedisRegistrationProvider.getPattern();
+    CLIENT.keys(pattern, function(err, keys) {
+        if (util.isError(err)) {
+            cb(err);
+            return;
+        }
+
+        CLIENT.mget(keys, function(err, statusObj) {
+
+            //do data transform
+            var statuses = [];
+            if (pb.utils.isObject(statusObj)) {
+                for (var key in statusObj) {
+                    try {
+                        var status = JSON.parse(statusObj[key]);
+                        status._id = key;
+                        statuses.push(status);
+                    }
+                    catch(e){}
+                }
+            }
+            cb(err, statuses);
+        });
+    });
+};
+
+/**
+ * Updates the status of a single node.
+ * @method set
+ * @param {String} id The unique identifier for the process/node
+ * @param {Object} status The status information
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+RedisRegistrationProvider.prototype.set = function(id, status, cb) {
+    if (!pb.utils.isObject(status)) {
+        cb(new Error('The status parameter must be a valid object'));
+        return;
+    }
+
+    var key    = RedisRegistrationProvider.getKey(id);
+    var expiry = Math.floor(pb.config.registry.update_interval / pb.utils.TIME.MILLIS_PER_SEC);
+    CLIENT.setex(key, expiry, JSON.stringify(status), cb);
+};
+
+/**
+ * Purges all statuses from storage.
+ * @method flush
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+RedisRegistrationProvider.prototype.flush = function(cb) {
+    var pattern = RedisRegistrationProvider.getPattern();
+    CLIENT.keys(pattern, function(err, keys) {
+        if (util.isError(err)) {
+            cb(err);
+            return;
+        }
+
+        CLIENT.del(keys, cb);
+    });
+};
+
+/**
+ * This function should only be called once at startup.  It is responsible for
+ * creating the Redis client that connects to the service registry.  It also
+ * ensures the proper Redis DB is selected.
+ * @static
+ * @method init
+ * @param {Function} cb A callback that takes two parameters. cb(Error, [RESULT])
+ */
+RedisRegistrationProvider.init = function(cb) {
+
+    CLIENT = pb.CacheFactory.createInstance();
+    CLIENT.select(REGISTRY_DB, cb);
+};
+
+/**
+ * Should be called during shutdown.  It is responsible for removing the
+ * process/node from the registry.
+ * @static
+ * @method shutdown
+ * @param {String} id The unique identifier for the node/process
+ * @param {Function} cb A callback that takes two parameters: cb(Error, [RESULT])
+ */
+RedisRegistrationProvider.shutdown = function(id, cb) {
+    if (!id) {
+        pb.log.error('RedisRegistrationProvider: A valid ID is needed in order to properly shutdown');
+        cb(null, false);
+    }
+
+    var key = RedisRegistrationProvider.getKey(id);
+    CLIENT.del(key, cb);
+};
+
+/**
+ * Creates the cache key used to store the status update
+ * @static
+ * @method getKey
+ * @param {String} id The unique identifier for the node/process
+ * @return {String} The cache key to be used for storing the update
+ */
+RedisRegistrationProvider.getKey = function(id) {
+    return [pb.config.registry.key, id].join(SEP);
+};
+
+/**
+ * Creates the glob pattern to be used to find service registry keys
+ * @static
+ * @method getPattern
+ * @return {String} The glob patern to be used to find all status updates
+ */
+RedisRegistrationProvider.getPattern = function() {
+    return pb.config.registry.key + '*';
+};
+
+//exports
+module.exports = RedisRegistrationProvider;

--- a/include/system/server_registration.js
+++ b/include/system/server_registration.js
@@ -15,14 +15,36 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
- function ServerRegistration(){}
+//dependencies
+var cluster              = require('cluster');
+var os                   = require('os');
+var domain               = require('domain');
+var RegistrationProvider = null;
 
- //dependencies
- var cluster = require('cluster');
- var os      = require('os');
- var domain  = require('domain');
+/**
+ * Service that provides the ability for the process/node to register itself so
+ * that other nodes in the system can find it.  In addition, it helps with the
+ * health monitoring of the system.
+ * @class ServerRegistration
+ * @constructor
+ */
+function ServerRegistration(){}
 
- //statics
+/**
+ * The instance of the RegistrationProvider interface to use as the storage
+ * provider.
+ * @private
+ * @property PROVIDER
+ * @type {RedisRegistrationProvider|MongoRegistrationProvider}
+ */
+var PROVIDER = null;
+
+ /**
+  * The default set of functions that gather the default set of information.
+  * @private
+  * @property ITEM_CALLBACKS
+  * @type {Object}
+  */
  var ITEM_CALLBACKS = {
 
 	 //ip address
@@ -75,56 +97,125 @@
 	 },
  };
 
- var TIMER_HANDLE = null;
+/**
+ * The handle to the interval that is set to ensure that updates are regularly
+ * sent to the storage provider.
+ * @private
+ * @property TIMER_HANDLE
+ * @type {Integer}
+ */
+var TIMER_HANDLE = null;
 
- ServerRegistration.prototype.getClusterStatus = function(cb) {
-	 pb.cache.hgetall(pb.config.registry.key, cb);
- };
+/**
+ * Retrieves the most recent status from the entire cluster.
+ * @method getClusterStatus
+ * @param {Function} cb A callback that provides two parameters: cb(Error, Array)
+ */
+ServerRegistration.prototype.getClusterStatus = function(cb) {
+	 PROVIDER.get(cb);
+};
 
 /**
  * Removes all entries from the server registry
- *
+ * @static
+ * @method flush
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
  */
 ServerRegistration.flush = function(cb) {
-    pb.cache.del(pb.config.registry.key, cb);
+    PROVIDER.flush(cb);
 };
 
- ServerRegistration.init = function() {
-	 if (!pb.config.registry.enabled) {
-		 return false;
+/**
+ * Should only be called once at startup.  The function verifies that the
+ * registry is enabled and initializes the correct storage provider.
+ * @static
+ * @method init
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+ServerRegistration.init = function(cb) {
+    if (!pb.config.registry.enabled) {
+		 cb(null, false);
 	 }
 	 else if (TIMER_HANDLE !== null) {
-		 return true;
+		 cb(null, true);
 	 }
 
-	 ServerRegistration.doRegistration();
-	 TIMER_HANDLE = setInterval(function() {
-		 ServerRegistration.doRegistration();
-	 }, pb.config.registry.update_interval);
- };
+     //identify the provider
+     RegistrationProvider = null;
+     if (pb.config.registry.type === 'redis') {
+         RegistrationProvider = pb.RedisRegistrationProvider;
+     }
+     else if (pb.config.registry.type === 'mongo') {
+        RegistrationProvider = pb.MongoRegistrationProvider;
+     }
+     else {
+        RegistrationProvider = require(pb.config.registry.type);
+     }
 
- ServerRegistration.shutdown = function(cb) {
+     //initialize the provider
+     RegistrationProvider.init(function(err, result) {
+
+         //create the provider instance
+         PROVIDER = new RegistrationProvider();
+
+         //do first update and schedule the rest
+         ServerRegistration.doRegistration();
+         TIMER_HANDLE = setInterval(function() {
+             ServerRegistration.doRegistration();
+         }, pb.config.registry.update_interval);
+
+         cb(err, true);
+     });
+};
+
+/**
+ * Called during shutdown.  The function is responsible for clearing any
+ * scheduled updates and shutting down the storage provider.
+ * @static
+ * @method shutdown
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+ServerRegistration.shutdown = function(cb) {
 	 cb = cb || pb.utils.cb;
 
 	 if (TIMER_HANDLE) {
 		 clearInterval(TIMER_HANDLE);
-		 pb.cache.hdel(pb.config.registry.key, ServerRegistration.generateKey(), cb);
+		 RegistrationProvider.shutdown(ServerRegistration.generateKey(), cb);
 	 }
 	 else {
 		 cb(null, true);
 	 }
- };
+};
 
- ServerRegistration.addItem = function(name, itemValueFunction) {
+/**
+ * Registers a function to be called on every status update.  The function
+ * should take one parameter: a callback function that accepts two parameters,
+ * the first being an error if it occurred and the second being the current
+ * value for the information requested.
+ * @static
+ * @method addItem
+ * @param {String} name The name and/or description of the information being
+ * gathered
+ * @param {Function} The function to be called to gather the data.
+ * @returns {Boolean} TRUE if the function is successfully registered, FALSE if not.
+ */
+ServerRegistration.addItem = function(name, itemValueFunction) {
 	 if (!pb.validation.validateNonEmptyStr(name, true) || !pb.utils.isFunction(itemValueFunction)) {
 		 return false;
 	 }
 
 	 ITEM_CALLBACKS[name] = itemValueFunction;
 	 return true;
- };
+};
 
- ServerRegistration.doRegistration = function(cb) {
+/**
+ * Performs the request for information and persists it through the storage
+ * provider.
+ * @static
+ * @method doRegistration
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+ServerRegistration.doRegistration = function(cb) {
 	 cb = cb || pb.utils.cb;
 
 	 var onItemsGathered = function(err, update) {
@@ -135,8 +226,8 @@ ServerRegistration.flush = function(cb) {
 		 if (update) {
 			 var key = ServerRegistration.generateKey();
 			 update.last_update = new Date();
-			 pb.cache.hset(pb.config.registry.key, key, JSON.stringify(update), function(err, result) {
-				 pb.log.debug("ServerRegistration: Attempted to update registration. KEY=[%s] Result=[%s] ERROR=[%s]", key, result === 1 || result === 0, err ? err.message : 'NONE');
+			 PROVIDER.set(key, update, function(err, result) {
+				 pb.log.debug("ServerRegistration: Attempted to update registration. KEY=[%s] Result=[%s] ERROR=[%s]", key, util.inspect(result), err ? err.message : 'NONE');
 				 if (pb.log.isSilly) {
 					 pb.log.silly("ServerRegistration: Last Update\n%s", util.inspect(update));
 				 }
@@ -155,13 +246,25 @@ ServerRegistration.flush = function(cb) {
 	 d.run(function() {
 		 async.parallel(ITEM_CALLBACKS, onItemsGathered);
 	 });
- };
+};
 
- ServerRegistration.generateKey = function() {
+/**
+ * Generates the unique key for the PB process/node.
+ * @static
+ * @method generateKey
+ * @returns {String} The unique identifier
+ */
+ServerRegistration.generateKey = function() {
 	 return  ServerRegistration.getIp() + ':' + pb.config.sitePort + ':' + (cluster.worker ? cluster.worker.id : 'master') + ':' + os.hostname();
- };
+};
 
- ServerRegistration.getIp = function() {
+/**
+ * Retrieves the first IP address found for the node.
+ * @static
+ * @method getIp
+ * @returns {String} The first IP address found for the node
+ */
+ServerRegistration.getIp = function() {
 	 var interfaces = os.networkInterfaces();
 	 var address = null;
 	 for (k in interfaces) {
@@ -174,7 +277,7 @@ ServerRegistration.flush = function(cb) {
 	     }
 	 }
 	 return address;
- };
+};
 
 //register for shutdown
 pb.system.registerShutdownHook('ServerRegistration', ServerRegistration.shutdown);

--- a/include/util.js
+++ b/include/util.js
@@ -27,6 +27,15 @@ var extend = require('node.extend');
  */
 function Util(){};
 
+/**
+ * Takes an array of promises and waits for each to be resolved before calling
+ * back.
+ * @static
+ * @method onPromisesOk
+ * @param {Array} promises
+ * @param {Function} A callback that takes zero arguments.  It is executed when
+ * all promises have been resolved.
+ */
 Util.onPromisesOk = function(promises, cb){
 
 	var cnt = 0;
@@ -46,7 +55,7 @@ Util.onPromisesOk = function(promises, cb){
 /**
  * Clones an object by serializing it and then re-parsing it.
  * WARNING: Objects with circular dependencies will cause an error to be thrown.
- *
+ * @static
  * @method clone
  * @param {Object} object The object to clone
  * @return {Object} Cloned object
@@ -59,7 +68,7 @@ Util.clone = function(object){
  * Performs a deep merge and returns the result.  <b>NOTE:</b> DO NOT ATTEMPT
  * TO MERGE PROPERTIES THAT REFERENCE OTHER PROPERTIES.  This could have
  * unintended side-effects as well as cause errors due to circular dependencies.
- *
+ * @static
  * @method deepMerge
  * @param {Object} from
  * @param {Object} to
@@ -72,7 +81,7 @@ Util.deepMerge = function(from, to) {
 /**
  * Checks if the supplied object is an errof. If the object is an error the
  * function will throw the error.
- *
+ * @static
  * @method ane
  * @param {Object} obj The object to check
  */
@@ -82,6 +91,13 @@ Util.ane = function(obj){
 	}
 };
 
+/**
+ * Escapes a regular expression.
+ * @static
+ * @method escapeRegExp
+ * @param {String} The expression to escape
+ * @return {String} Escaped regular expression.
+ */
 Util.escapeRegExp = function(str) {
 	if (!Util.isString(str)) {
 		return null;
@@ -103,6 +119,13 @@ Util.merge = function(from, to) {
 	}
 };
 
+/**
+ * Creates an object that has both the properties of "a" and "b".  When both
+ * objects have a property with the same name, "b"'s value will be preserved.
+ * @static
+ * @method union
+ * @return {Object} The union of properties from both a and b.
+ */
 Util.union = function(a, b) {
 	var union = {};
 	Util.merge(a, union);
@@ -110,6 +133,25 @@ Util.union = function(a, b) {
 	return union;
 };
 
+/**
+ * Creates a set of tasks that can be executed by the "async" module.
+ * @static
+ * @method getTasks
+ * @param {Array} iterable The array of items to build tasks for
+ * @param {Function} getTaskFunction The function that creates and returns the
+ * task to be executed.
+ * @example
+ * <code>
+ * var items = ['apple', 'orange'];
+ * var tasks = pb.utils.getTasks(items, function(items, i) {
+ *     return function(callback) {
+ *         console.log(items[i]);
+ *         callback(null, null);
+ *     };
+ * });
+ * async.series(tasks, pb.utils.cb);
+ * <code>
+ */
 Util.getTasks = function (iterable, getTaskFunction) {
 	var tasks = [];
 	for (var i = 0; i < iterable.length; i++) {
@@ -120,7 +162,7 @@ Util.getTasks = function (iterable, getTaskFunction) {
 
 /**
  * Hashes an array
- *
+ * @static
  * @method arrayToHash
  * @param {Array} array      The array to hash
  * @param {*} defaultVal Default value if the hashing fails
@@ -145,27 +187,33 @@ Util.arrayToHash = function(array, defaultVal) {
 };
 
 /**
- * Converts a hash to an array
- *
+ * Converts a hash to an array. When provided, the hashKeyProp will be the
+ * property name of each object in the array that holds the hash key.
+ * @static
  * @method hashToArray
- * @param {Object} obj Hash object
- * @return {Array}
+ * @param {Object} obj The object to convert
+ * @param {String} [hashKeyProp] The property name that will hold the hash key.
+ * @return {Array} An array of each property value in the hash.
  */
-Util.hashToArray = function(obj) {
+Util.hashToArray = function(obj, hashKeyProp) {
 	if (!Util.isObject(obj)) {
 		return null;
 	}
 
-	var a = [];
+	var a                  = [];
+    var doHashKeyTransform = Util.isString(hashKeyProp);
 	for (var prop in obj) {
 		a.push(obj[prop]);
+        if (doHashKeyTransform) {
+            obj[prop][hashKeyProp] = prop;
+        }
 	}
 	return a;
 };
 
 /**
  * Inverts a hash
- *
+ * @static
  * @method invertHash
  * @param {Object} obj Hash object
  * @return {Object} Inverted hash
@@ -186,7 +234,7 @@ Util.invertHash = function(obj) {
 
 /**
  * Clones an array
- *
+ * @static
  * @method copyArray
  * @param {Array} array
  * @return {Array} Cloned array
@@ -205,6 +253,8 @@ Util.copyArray = function(array) {
 
 /**
  * Pushes all of one array's values into another
+ * @static
+ * @method arrayPushAll
  * @param {Array} from
  * @param {Array} to
  */
@@ -221,6 +271,8 @@ Util.arrayPushAll = function(from, to) {
 /**
  * Empty callback function just used as a place holder if a callback is required
  * and the result is not needed.
+ * @static
+ * @method cb
  */
 Util.cb = function(err, result){
 	//do nothing
@@ -228,9 +280,9 @@ Util.cb = function(err, result){
 
 /**
  * Creates a unique Id
- *
+ * @static
  * @method uniqueId
- * @return {Object} Unique Id Object
+ * @return {ObjectID} Unique Id Object
  */
 Util.uniqueId = function(){
 	return new ObjectID();
@@ -238,7 +290,7 @@ Util.uniqueId = function(){
 
 /**
  * Tests if a value is an object
- *
+ * @static
  * @method isObject
  * @param {*} value
  * @return {Boolean}
@@ -249,7 +301,7 @@ Util.isObject = function(value) {
 
 /**
  * Tests if a value is an string
- *
+ * @static
  * @method isString
  * @param {*} value
  * @return {Boolean}
@@ -260,7 +312,7 @@ Util.isString = function(value) {
 
 /**
  * Tests if a value is a function
- *
+ * @static
  * @method isFunction
  * @param {*} value
  * @return {Boolean}
@@ -271,7 +323,7 @@ Util.isFunction = function(value) {
 
 /**
  * Tests if a value is a boolean
- *
+ * @static
  * @method isBoolean
  * @param {*} value
  * @return {Boolean}
@@ -282,6 +334,8 @@ Util.isBoolean = function(value) {
 
 /**
  * Retrieves the subdirectories of a path
+ * @static
+ * @method getDirectories
  * @param {String}   dirPath The starting path
  * @param {Function} cb      Callback function
  */
@@ -315,6 +369,11 @@ Util.getDirectories = function(dirPath, cb) {
 	});
 };
 
+/**
+ * Provides typical conversions for time
+ * @property TIME
+ * @type {Object}
+ */
 Util.TIME = {
 
 	MILLIS_PER_SEC: 1000,
@@ -323,4 +382,5 @@ Util.TIME = {
 	MILLIS_PER_DAY: 86400000
 };
 
+//exports
 module.exports = Util;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
     	"async": "0.2.9",
     	"cookies": "0.4.0",
-    	"fakeredis": "0.1.1",
+    	"fakeredis": "0.2.0",
 	    "formidable": "1.0.14",
         "htmlencode": "0.0.4",
 	    "locale": "0.0.14",

--- a/pencilblue.js
+++ b/pencilblue.js
@@ -18,6 +18,14 @@
 // A grouping of all require calls
 global.pb = require('./include/requirements');
 
+/**
+ * The main driver file for PencilBlue.  Provides the function necessary to
+ * start up the master and/or child processes.  In addition, it is responsible
+ * for ensuring that all system services are avaialble by requiring the
+ * "requirements.js" file.
+ * @class PencilBlue
+ * @constructor
+ */
 function PencilBlue(){}
 
 /**
@@ -31,8 +39,7 @@ PencilBlue.init = function(){
          PencilBlue.initDBConnections,
          PencilBlue.initServer,
          PencilBlue.initPlugins,
-         PencilBlue.initServerRegistration,
-         PencilBlue.registerSystemForEvents
+         PencilBlue.initServerRegistration
      ];
 	async.series(tasks, function(err, results) {
 		if (util.isError(err)) {
@@ -42,17 +49,33 @@ PencilBlue.init = function(){
 	});
 };
 
+/**
+ * Initializes the request handler.  This causes all system routes to be
+ * registered.
+ * @static
+ * @method initRequestHandler
+ * @param {Function} cb A callback that provides two parameters: cb(Error, Boolean)
+ */
 PencilBlue.initRequestHandler = function(cb) {
 	pb.RequestHandler.init();
 	cb(null, true);
 }
 
+/**
+ * Initializes the installed plugins.
+ * @static
+ * @method initPlugins
+ * @param {Function} cb A callback that provides two parameters: cb(Error, Boolean)
+ */
 PencilBlue.initPlugins = function(cb) {
     pb.plugins.initPlugins(cb);
 };
 
 /**
  * Attempts to initialize a connection pool to the core database
+ * @static
+ * @method initDBConnections
+ * @param {Function} cb A callback that provides two parameters: cb(Error, Boolean)
  */
 PencilBlue.initDBConnections = function(cb){
 	//setup database connection to core database
@@ -72,7 +95,11 @@ PencilBlue.initDBConnections = function(cb){
 };
 
 /**
- * Initializes the server
+ * Initializes the HTTP server(s).  When SSL is enabled two servers are created.
+ * One to handle incoming HTTP traffic and one to handle HTTPS traffic.
+ * @static
+ * @method initServer
+ * @param {Function} cb A callback that provides two parameters: cb(Error, Boolean)
  */
 PencilBlue.initServer = function(cb){
 	log.debug('Starting server...');
@@ -107,6 +134,17 @@ PencilBlue.initServer = function(cb){
 	}
 }
 
+/**
+ * The function that handles normal server traffic.  The function ensures that
+ * the incoming request is delegated out appropriately.  When SSL Termination
+ * is in use if the 'x-forwarded-proto' header does equal 'https' then the
+ * request is delegated to the handoff function so the request can be
+ * redirected appropriately.
+ * @static
+ * @method onHttpConnect
+ * @param {Request} req The incoming request
+ * @param {Response} resp The outgoing response
+ */
 PencilBlue.onHttpConnect = function(req, resp){
 	if (pb.log.isSilly()) {
 		req.uid = new ObjectID();
@@ -127,6 +165,14 @@ PencilBlue.onHttpConnect = function(req, resp){
     handler.handleRequest();
 };
 
+/**
+ * Handles traffic that comes in for HTTP when SSL is enabled.  The request is
+ * redirected to the appropriately protected HTTPS url.
+ * @static
+ * @method onHttpConnectForHandoff
+ * @param {Request} req The incoming request
+ * @param {Response} res The outgoing response
+ */
 PencilBlue.onHttpConnectForHandoff = function(req, res) {
     var host = req.headers.host;
     if (host) {
@@ -143,8 +189,14 @@ PencilBlue.onHttpConnectForHandoff = function(req, res) {
     res.end();
 };
 
-PencilBlue.initServerRegistration = function() {
-	pb.ServerRegistration.init();
+/**
+ * Initializes server registration.
+ * @static
+ * @method initServerRegistration
+ * @param {Function} cb A callback that provides two parameters: cb(Error, [RESULT])
+ */
+PencilBlue.initServerRegistration = function(cb) {
+	pb.ServerRegistration.init(cb);
 };
 
 //start system

--- a/public/js/admin/index.js
+++ b/public/js/admin/index.js
@@ -99,10 +99,13 @@ function refreshServers() {
       left: '50%' // Left position relative to parent
     };
     $('#cluster_info_table').spin(opts);
-    $.post('/api/cluster/refresh', {}, function(data, status, xhr) {
-        setTimeout(function() {window.location.reload();}, data.data.wait);
-    }, 'json')
-    .failure(function() {
 
+    var xhr = $.post('/api/cluster/refresh', {}, function(data, status, xhr) {
+        setTimeout(function() {
+            window.location.reload();
+        }, data.data.wait);
+    }, 'json');
+    xhr.fail(function() {
+        window.location.reload();
     });
 }


### PR DESCRIPTION
There are now two service registration providers: redis and mongo.  It is also possible to specify your own by providing an absolute path to the "type" property for config.registry.type.  In addition, there are multiple documentation improvements.
