### PR TITLE
Fixes #118. Fix for incorrect redirect of attempt to create new custom object

### DIFF
--- a/controllers/actions/admin/content/custom_objects/new_object.js
+++ b/controllers/actions/admin/content/custom_objects/new_object.js
@@ -50,19 +50,20 @@ NewObject.prototype.onPostParamsRetrieved = function(post, cb) {
 
 		var message = self.hasRequiredParams(post, ['name']);
 	    if(message) {
-            self.formError(message, '/admin/content/custom_objects/new_object/' + customObjectType.name, cb);
+            self.formError(message, '/admin/content/custom_objects/new_object/' + customObjectType._id, cb);
             return;
         }
 
         // Test for duplicate name
-        dao.query('custom_object', {type: vars.type_id, name: post.name}).then(function(customObjects) {
-		    if (util.isError(customObjects)) {
-			    //TODO handle this
+        dao.count('custom_object', {type: vars.type_id, name: post.name}, function(err, count) {
+		    if (util.isError(err)) {
+                self.reqHandler.serveError(err);
+                return;
 		    }
 
-		    if(customObjects.length > 0)
-		    {
-		        self.formError(self.ls.get('EXISTING_CUSTOM_OBJECT'), '/admin/content/custom_objects/new_object/' + customObjectType.name, cb);
+		    if(count > 0) {
+                self.setFormFieldValues(post);
+		        self.formError(self.ls.get('EXISTING_CUSTOM_OBJECT'), '/admin/content/custom_objects/new_object/' + customObjectType._id, cb);
                 return;
 		    }
 

--- a/controllers/admin/content/custom_objects/new_object.js
+++ b/controllers/admin/content/custom_objects/new_object.js
@@ -80,13 +80,11 @@ NewObject.prototype.render = function(cb) {
                 self.ts.registerLocal('angular_script', angularData);
                 self.ts.registerLocal('custom_object_script', pb.js.getJSTag('var customObjectType = ' + JSON.stringify(objectType)));
                 self.ts.load('admin/content/custom_objects/new_object', function(err, data) {
-                    var result = '' + data;
-                    cb({content: result});
+                    self.checkForFormRefill('' + data, function(result) {
+                        cb({content: result});
+                    });
                 });
             });
-
-
-
         });
     });
 };

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -1504,9 +1504,12 @@ RequestHandler.prototype.checkSecurity = function(activeTheme, method, cb){
 RequestHandler.prototype.onControllerInitialized = function(controller) {
 	var self = this;
     var d = domain.create();
+    d.add(controller);
     d.run(function() {
-        controller.render(function(result){
-            self.onRenderComplete(result);
+        process.nextTick(function() {
+            controller.render(function(result){
+                self.onRenderComplete(result);
+            });
         });
 	});
     d.on('error', function(err) {

--- a/public/localization/en-us.js
+++ b/public/localization/en-us.js
@@ -142,6 +142,7 @@ var loc =
         CLOSE: 'Close',
         APPLY_SETTINGS: 'Apply Settings',
         CONFIGURATION_SETTINGS: 'Configuration Settings',
+        EXISTING_CUSTOM_OBJECT: 'The custom object with the given name already exists',
     },
     error:
     {


### PR DESCRIPTION
Fixes #118. Fix for incorrect redirect of attempt to create new custom object when validation fails on duplicate name.
