### PR TITLE
Added a double quote to font-awesome's link

### DIFF
--- a/templates/head.html
+++ b/templates/head.html
@@ -17,7 +17,7 @@
         <link rel="shortcut icon" href="^site_icon^">
 
         <link rel="stylesheet" type="text/css" href="^bootstrap_css_src^">
-        <link rel="stylesheet" type="text/css" href=^font_awesome_src^">
+        <link rel="stylesheet" type="text/css" href="^font_awesome_src^">
         <link rel="stylesheet" type="text/css" href="/css/pencilblue_theme.css">
 
         <script type="text/javascript" src="^jquery_src^"></script>


### PR DESCRIPTION
The font-awesome's link was missing a leading double quote in the src attribute on line 20 which caused an Access Denied error when page was loaded so I added the double quote.
