### PR TITLE
Added uninstall implementation to sample plugin

### DIFF
--- a/plugins/sample/sample.js
+++ b/plugins/sample/sample.js
@@ -14,8 +14,6 @@ function SamplePlugin(){}
  * The result should be TRUE on success and FALSE on failure
  */
 SamplePlugin.onInstall = function(cb) {
-	// Remove "sample" nav during uninstall
-    	pb.AdminNavigation.remove("sample");
 	cb(null, true);
 };
 
@@ -28,6 +26,8 @@ SamplePlugin.onInstall = function(cb) {
  * The result should be TRUE on success and FALSE on failure
  */
 SamplePlugin.onUninstall = function(cb) {
+	// Remove "sample" nav during uninstall
+    	pb.AdminNavigation.remove("sample");
 	cb(null, true);
 };
 


### PR DESCRIPTION
The sample navigation is removed from the top level node during uninstall of the sample plugin
