### PR TITLE
pass in pb.config.siteIP to pb.server.listen

### DIFF
--- a/pencilblue.js
+++ b/pencilblue.js
@@ -146,7 +146,7 @@ PencilBlue.initServer = function(cb){
         else {
             pb.server = http.createServer(PencilBlue.onHttpConnect);
         }
-		pb.server.listen(pb.config.sitePort, function() {
+		pb.server.listen(pb.config.sitePort, pb.config.siteIP, function() {
 			log.info('PencilBlue: %s running at site root [%s] on port [%d]', pb.config.siteName, pb.config.siteRoot, pb.config.sitePort);
 			cb(null, true);
 		});


### PR DESCRIPTION
node uses 0.0.0.0 as default during server.listen.

OpenShift does not let you bind do this IP and throws EACCES during connection. 

The 'default' siteIP might want to be switched to 0.0.0.0 to make this a non-breaking change.
