### PR TITLE
Fixed autocomplete if translated, get type from angular

### DIFF
--- a/public/js/admin/elements/content_search.js
+++ b/public/js/admin/elements/content_search.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
                 url: "/api/content/search/",
                 dataType: "json",
                 data: {
-                   type: $('#content_type option:selected').text().toLowerCase(),
+                   type: angular.element('#content_type').scope().navItem.type,
                    q: $('#content_search').val(),
                 },
                 success: function( data ) {


### PR DESCRIPTION
The api could not handle search type ('article', 'page') if the site is translated i.e. ('beitrag','seite') in german. So I took the type from angular scope, where it's not translated.