### PR TITLE
Fixes #95 Adds a TTL index to the 'unverified_user' collection to ensure...

### DIFF
--- a/include/config.js
+++ b/include/config.js
@@ -134,6 +134,13 @@ var config = {
                 spec: {admin: DESC},
                 options: {}
             },
+            
+            //unverified user
+            {
+                collection: 'unverified_user',
+                spec: { last_modified: ASC },
+                options: { expireAfterSeconds: 2592000 }
+            },
 
             //theme settings
             {


### PR DESCRIPTION
... that any lingering users that did not complete registration are cleaned up after 30 days