### PR TITLE
Plugin Uninstall Error Typo. Stopped Active Plugins From Unregistering

### DIFF
--- a/include/service/jobs/plugins/plugin_uninstall_job.js
+++ b/include/service/jobs/plugins/plugin_uninstall_job.js
@@ -169,7 +169,7 @@ PluginUninstallJob.prototype.getWorkerTasks = function(cb) {
             };
             var dao = new pb.DAO();
             dao.delete(where, 'plugin', function(err, result) {
-                callback(error, !util.isError(err));
+                callback(err, !util.isError(err));
             });
         },
 


### PR DESCRIPTION
After great feedback from @brianhyder on the clean plugin. I added some code to remove the plugin from nav on uninstall.

Whilst Installing <-> Uninstalling, I noticed that the plugin was not removing from nav until a process restart. Turns out there is an typo on the error param in the uninstall plugin job, which stops the plugin from being removed from `ACTIVE_PLUGINS` object.

