### PR TITLE
Skip date field validation if empty

### DIFF
--- a/public/js/angular/filters/parsable_date.js
+++ b/public/js/angular/filters/parsable_date.js
@@ -1,6 +1,8 @@
 angular.module('parseDate', [])
 .filter('parsableDate', function() {
     return function(input) {
+        if(typeof(input)==='undefined')
+            return '';
         var csv = input.split('-').join(',')
                        .split(' ').join(',')
                        .split(':').join(',');


### PR DESCRIPTION
Empty date fields should not prevent submission (e.g. - when there is a publish up/publish down date setting for a custom object)