### PR TITLE
Adding MIME types for fonts and fixing public route QSVars

### DIFF
--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -420,6 +420,8 @@ RequestHandler.getMimeFromPath = function(resourcePath) {
         tff: 'application/octet-stream',
         eot: 'application/vnd.ms-fontobject',
         woff: 'application/x-font-woff',
+        otf: 'font/opentype',
+        ttf: 'font/truetype',
         html: 'text/html'
     };
     var index = resourcePath.lastIndexOf('.');

--- a/plugins/pencilblue/controllers/public.js
+++ b/plugins/pencilblue/controllers/public.js
@@ -52,7 +52,8 @@ PluginPublicContentController.prototype.render = function(cb) {
 
     //serve up the content
 	var resourcePath = path.join(pluginPublicDir, postPluginPath);
-	this.reqHandler.servePublicContent(resourcePath);
+	//remove qsvars before loading files
+	this.reqHandler.servePublicContent(resourcePath.split('?')[0]);
 };
 
 //exports


### PR DESCRIPTION
Adding MIME types for otf and ttf fonts to eliminate browser warnings about incorrect MIME types.  Making sure qsvars are valid for public resource routes, currently qsvars cause public resource routes to error.