### PR TITLE
use the correct instance variable

### DIFF
--- a/include/service/entities/media_service.js
+++ b/include/service/entities/media_service.js
@@ -881,7 +881,7 @@ module.exports = function MediaServiceModule(pb) {
         for(var i = 0; i < paths.length; i++) {
             try{
                 var ProviderType = require(paths[i])(pb);
-                INSTANCE = new ProviderType();
+                instance = new ProviderType();
                 break;
             }
             catch(e){


### PR DESCRIPTION
Fixes a bug where it would fail to load custom media service providers.