### PR TITLE
check for property before execute toLowerCase()

### DIFF
--- a/include/service/entities/custom_object_service.js
+++ b/include/service/entities/custom_object_service.js
@@ -494,7 +494,7 @@ module.exports = function CustomObjectServiceModule(pb) {
                 //currently, mongo cannot do case-insensitive sorts.  We do it manually
                 //until a solution for https://jira.mongodb.org/browse/SERVER-90 is merged.
                 custObjTypes.sort(function(a, b) {
-                    var x = a.name.toLowerCase();
+                    var x = a.name ? a.name.toLowerCase() : null;
                     var y = b.name.toLowerCase();
 
                     return ((x < y) ? -1 : ((x > y) ? 1 : 0));


### PR DESCRIPTION
I don't know how did I cause it (didn't code anything, just clicked around on the admin), but when I visited: 
http://localhost:8080/admin/content/objects/types
I got the failure: 

Whoops! Something unexpected happened.
TypeError: Cannot call method 'toLowerCase' of undefine

What I did is just a really small bugfix, now it works, but it would be interesting to investigate the core problem.