### PR TITLE
Fix topic import bug

### DIFF
--- a/plugins/wp_import/services/wp_xml_parse.js
+++ b/plugins/wp_import/services/wp_xml_parse.js
@@ -233,7 +233,14 @@ module.exports = function WPXMLParseServiceModule(pb) {
                     }
 
                     //we're all good.  we can persist now
-                    dao.save(topic, callback);
+                    dao.save(topic, function(err, result) {
+                        if (util.isError(err)) {
+                            return callback(err);
+                        }
+
+                        pb.log.debug('WPXMLParseService: Created topic [%s]', topic.name);
+                        callback(null, topic);
+                    });
                 });
             };
         });


### PR DESCRIPTION
Fixing a bug where newly created topics weren't being returned from the task. This was preventing topics created as part of the import process from being associated with any articles that were imported at the same time.