### PR TITLE
Windows upload fix

### DIFF
--- a/include/service/media/renderers/audio_media_renderer.js
+++ b/include/service/media/renderers/audio_media_renderer.js
@@ -126,7 +126,7 @@ module.exports = function AudioMediaRendererModule(pb) {
      * @return {Boolean} TRUE if the URL is supported by the renderer, FALSE if not
      */
     AudioMediaRenderer.isSupported = function(urlStr) {
-        var ext = util.getExtension(urlStr, {lower: true});
+        var ext = util.getExtension(urlStr, {lower: true, sep: '/'});
         return SUPPORTED[ext] ? true : false;
     };
 

--- a/include/service/media/renderers/image_media_renderer.js
+++ b/include/service/media/renderers/image_media_renderer.js
@@ -128,7 +128,7 @@ module.exports = function ImageMediaRendererModule(pb) {
      * @return {Boolean} TRUE if the URL is supported by the renderer, FALSE if not
      */
     ImageMediaRenderer.isSupported = function(urlStr) {
-        var ext = util.getExtension(urlStr, {lower: true});
+        var ext = util.getExtension(urlStr, {lower: true, sep: '/'});
         return SUPPORTED[ext] ? true : false;
     };
 

--- a/include/service/media/renderers/video_media_renderer.js
+++ b/include/service/media/renderers/video_media_renderer.js
@@ -129,7 +129,7 @@ module.exports = function VideoMediaRendererModule(pb) {
      * @return {Boolean} TRUE if the URL is supported by the renderer, FALSE if not
      */
     VideoMediaRenderer.isSupported = function(urlStr) {
-        var ext = util.getExtension(urlStr, {lower: true});
+        var ext = util.getExtension(urlStr, {lower: true, sep: '/'});
         return SUPPORTED[ext] ? true : false;
     };
 

--- a/include/util.js
+++ b/include/util.js
@@ -705,8 +705,9 @@ Util.getExtension = function(filePath, options) {
     
     //do to the end of the path
     var pathPartIndex = filePath.lastIndexOf(options.sep || path.sep) || 0;
-    if (pathPartIndex > -1)
-    	filePath = filePath.substr(pathPartIndex);
+    if (pathPartIndex > -1) {
+			filePath = filePath.substr(pathPartIndex);
+		}
     
     var ext = null;
     var index = filePath.lastIndexOf('.');

--- a/include/util.js
+++ b/include/util.js
@@ -705,7 +705,8 @@ Util.getExtension = function(filePath, options) {
     
     //do to the end of the path
     var pathPartIndex = filePath.lastIndexOf(options.sep || path.sep) || 0;
-    filePath = filePath.substr(pathPartIndex);
+    if (pathPartIndex > -1)
+    	filePath = filePath.substr(pathPartIndex);
     
     var ext = null;
     var index = filePath.lastIndexOf('.');


### PR DESCRIPTION
Fixes #549 - Makes the changes as discussed in issue #549 to fix media upload when running PencilBlue on a Windows machine.