### PR TITLE
fix reference error in theme settings page controller

### DIFF
--- a/plugins/pencilblue/controllers/admin/themes/theme_settings.js
+++ b/plugins/pencilblue/controllers/admin/themes/theme_settings.js
@@ -31,7 +31,7 @@ module.exports = function(pb) {
          * @property pluginService
          * @type {PluginService}
          */
-        this.pluginService = new PluginService();
+        this.pluginService = new pb.PluginService();
     }
     util.inherits(ThemeSettings, PluginSettings);
 


### PR DESCRIPTION
fixes a simple reference error in the theme settings management page's controller