### PR TITLE
Fixing sort order bug.

### DIFF
--- a/include/dao/dao.js
+++ b/include/dao/dao.js
@@ -322,8 +322,9 @@ module.exports = function DAOModule(pb) {
                 .skip(offset);
 
             //apply sort order
-            if (options.order) {
-                cursor.sort(options.order);
+            var orderBy = options.order || options.orderBy;
+            if (orderBy) {
+                cursor.sort(orderBy);
             }
 
             //apply maximum number of results to return
@@ -335,9 +336,9 @@ module.exports = function DAOModule(pb) {
             if(pb.config.db.query_logging){
                 var query = "DAO: SELECT %j FROM %s.%s WHERE %j";
                 var args = [select, self.dbName, entityType, where];
-                if (typeof options.order !== 'undefined') {
+                if (typeof orderBy !== 'undefined') {
                     query += " ORDER BY %j";
-                    args.push(options.order);
+                    args.push(orderBy);
                 }
                 if (typeof options.limit !== 'undefined') {
                     query += " LIMIT %d, OFFSET %d";

--- a/include/dao/dao.js
+++ b/include/dao/dao.js
@@ -293,7 +293,8 @@ module.exports = function DAOModule(pb) {
      * @param {String} entityType The collection to query
      * @param {Object} [where={}] The where clause
      * @param {Object} [select={}] The fields to project
-     * @param {Array} [orderBy] The ordering
+     * @param {Array} [order] The ordering
+     * @param {Array} [orderBy] The ordering. Parameter orderBy is deprecated, use order instead.
      * @param {Integer} [limit] The maximum number of results to return
      * @param {Integer} [offset] The number of results to skip before returning results.
      * @return {Cursor} The MongoDB cursor that provides the results of the query

--- a/include/dao/dao.js
+++ b/include/dao/dao.js
@@ -322,8 +322,8 @@ module.exports = function DAOModule(pb) {
                 .skip(offset);
 
             //apply sort order
-            if (options.orderBy) {
-                cursor.sort(options.orderBy);
+            if (options.order) {
+                cursor.sort(options.order);
             }
 
             //apply maximum number of results to return
@@ -335,13 +335,13 @@ module.exports = function DAOModule(pb) {
             if(pb.config.db.query_logging){
                 var query = "DAO: SELECT %j FROM %s.%s WHERE %j";
                 var args = [select, self.dbName, entityType, where];
-                if (typeof orderBy !== 'undefined') {
+                if (typeof options.order !== 'undefined') {
                     query += " ORDER BY %j";
-                    args.push(orderBy);
+                    args.push(options.order);
                 }
-                if (typeof limit !== 'undefined') {
+                if (typeof options.limit !== 'undefined') {
                     query += " LIMIT %d, OFFSET %d";
-                    args.push(limit, offset);
+                    args.push(options.limit, offset);
                 }
                 args.unshift(query);
                 pb.log.info(util.format.apply(util, args));

--- a/include/service/entities/article_service.js
+++ b/include/service/entities/article_service.js
@@ -132,11 +132,11 @@ module.exports = function ArticleServiceModule(pb) {
 
         //build out the ordering
         var order;
-        if (util.isArray(options.order)) {
+        if (util.isObject(options.order)) {
             order = options.order;
         }
         else {
-            order = [{'publish_date': pb.DAO.DESC}, {'created': pb.DAO.DESC}];
+            order = {'publish_date': pb.DAO.DESC, 'created': pb.DAO.DESC};
         }
 
         //build out select

--- a/include/service/entities/article_service.js
+++ b/include/service/entities/article_service.js
@@ -136,7 +136,7 @@ module.exports = function ArticleServiceModule(pb) {
             order = options.order;
         }
         else {
-            order = [['publish_date', pb.DAO.DESC], ['created', pb.DAO.DESC]];
+            order = [{'publish_date': pb.DAO.DESC}, {'created': pb.DAO.DESC}];
         }
 
         //build out select

--- a/include/service/entities/article_service.js
+++ b/include/service/entities/article_service.js
@@ -132,11 +132,11 @@ module.exports = function ArticleServiceModule(pb) {
 
         //build out the ordering
         var order;
-        if (util.isObject(options.order)) {
+        if (options.order) {
             order = options.order;
         }
         else {
-            order = {'publish_date': pb.DAO.DESC, 'created': pb.DAO.DESC};
+            order = [{'publish_date': pb.DAO.DESC}, {'created': pb.DAO.DESC}];
         }
 
         //build out select

--- a/include/service/entities/custom_object_service.js
+++ b/include/service/entities/custom_object_service.js
@@ -484,9 +484,7 @@ module.exports = function CustomObjectServiceModule(pb) {
         var opts = {
             where: pb.DAO.ANYWHERE,
             select: pb.DAO.PROJECT_ALL,
-            order: [
-                {NAME_FIELD: pb.DAO.ASC}
-            ]
+            order: {NAME_FIELD: pb.DAO.ASC}
         };
         var dao  = new pb.DAO();
         dao.q(CustomObjectService.CUST_OBJ_TYPE_COLL, opts, function(err, custObjTypes) {

--- a/include/service/entities/custom_object_service.js
+++ b/include/service/entities/custom_object_service.js
@@ -485,7 +485,7 @@ module.exports = function CustomObjectServiceModule(pb) {
             where: pb.DAO.ANYWHERE,
             select: pb.DAO.PROJECT_ALL,
             order: [
-                [NAME_FIELD, pb.DAO.ASC]
+                {NAME_FIELD: pb.DAO.ASC}
             ]
         };
         var dao  = new pb.DAO();

--- a/include/service/entities/job_service.js
+++ b/include/service/entities/job_service.js
@@ -48,7 +48,7 @@ module.exports = function JobServiceModule(pb) {
             created: {$gte: startingDate}
         };
         var orderBy = [
-            ['created', pb.DAO.ASC]
+            {'created': pb.DAO.ASC}
         ];
 
         var dao = new pb.DAO();

--- a/include/service/entities/job_service.js
+++ b/include/service/entities/job_service.js
@@ -47,9 +47,7 @@ module.exports = function JobServiceModule(pb) {
             job_id: jid,
             created: {$gte: startingDate}
         };
-        var orderBy = [
-            {'created': pb.DAO.ASC}
-        ];
+        var orderBy = {'created': pb.DAO.ASC};
 
         var dao = new pb.DAO();
         dao.q('job_log', {where: where, select: pb.DAO.SELECT_ALL, order: orderBy}, cb);

--- a/include/service/entities/section_service.js
+++ b/include/service/entities/section_service.js
@@ -292,7 +292,7 @@ module.exports = function SectionServiceModule(pb) {
         cb = cb || currItem;
 
         var where = {
-            type: 'container',
+            type: 'container'
         };
         if (currItem && !util.isFunction(currItem)) {
             where[pb.DAO.getIdField()] = pb.DAO.getNotIdField(currItem);
@@ -305,7 +305,7 @@ module.exports = function SectionServiceModule(pb) {
             },
             where: where,
             order: [
-                ['name', pb.DAO.ASC]
+                {'name': pb.DAO.ASC}
             ]
         };
         var dao = new pb.DAO();

--- a/include/service/entities/section_service.js
+++ b/include/service/entities/section_service.js
@@ -304,9 +304,7 @@ module.exports = function SectionServiceModule(pb) {
                 name: 1
             },
             where: where,
-            order: [
-                {'name': pb.DAO.ASC}
-            ]
+            order: {'name': pb.DAO.ASC}
         };
         var dao = new pb.DAO();
         dao.q('section', opts, cb);


### PR DESCRIPTION
The DAO was looking for "orderBy" property in the options, while the sort order was being passed in a property named "order". Also, several services were building sort order as an array of arrays, while MongoDB sort order should always be an object or array of objects. As soon as I fixed dao.js all those array of arrays started causing errors.

Apparently the natural sort order was always returning items in the order you would expect, so this wasn't very noticeable. However as soon as I added a query to my template to return articles with a given topic the sort order began to appear random, which is what led me to find this bug.

I also removed a stray comma in section_service.js, and I fixed the logging of sort order, limit and offset values in dao.js