### PR TITLE
Prevent draft articles and pages from showing up in feed and sitemap.

### DIFF
--- a/plugins/pencilblue/controllers/feed.js
+++ b/plugins/pencilblue/controllers/feed.js
@@ -42,7 +42,7 @@ module.exports = function FeedModule(pb) {
 
             var opts = {
                 select: pb.DAO.PROJECT_ALL,
-                where: {publish_date: {$lte: new Date()}},
+                where: {publish_date: {$lte: new Date()}, draft: {$ne: 1}},
                 order: {publish_date: pb.DAO.DESC},
                 limit: 100
             };

--- a/plugins/pencilblue/controllers/sitemap.js
+++ b/plugins/pencilblue/controllers/sitemap.js
@@ -46,12 +46,12 @@ module.exports = function SiteMapModule(pb) {
                     path: '/'
                 },
                 page: {
-                    where: {publish_date: {$lte: today}},
+                    where: {publish_date: {$lte: today}, draft: {$ne: 1}},
                     weight: '1.0',
                     path: '/page/'
                 },
                 article: {
-                    where: {publish_date: {$lte: today}},
+                    where: {publish_date: {$lte: today}, draft: {$ne: 1}},
                     weight: '1.0',
                     path: '/article/'
                 }


### PR DESCRIPTION
I just noticed a draft article showing up in my RSS feed. Draft articles and pages weren't being filtered out of the RSS feed or the sitemap. This commit fixes that.