### PR TITLE
Properly obtain EmailService instance

### DIFF
--- a/plugins/pencilblue/controllers/api/admin/site_settings/email/send_test.js
+++ b/plugins/pencilblue/controllers/api/admin/site_settings/email/send_test.js
@@ -41,9 +41,10 @@ module.exports = function(pb) {
             var options = {
                 to: post.email,
                 subject: 'Test email from PencilBlue',
-                layout: 'This is a successful test email from the PencilBlue system.',
+                layout: 'This is a successful test email from the PencilBlue system.'
             };
-            pb.email.sendFromLayout(options, function(err, response) {
+            var emailService = new pb.EmailService();
+            emailService.sendFromLayout(options, function(err, response) {
                 if(err) {
                     return cb({
                         code: 500,


### PR DESCRIPTION
Fixing a bug where the email test function wasn't getting an instance of EmailService correctly, resulting in an error when you tried sending a test email.