### PR TITLE
Fixing articleService.getMetaInfo() calls to work with the new version.

### DIFF
--- a/plugins/pencilblue/controllers/index.js
+++ b/plugins/pencilblue/controllers/index.js
@@ -47,11 +47,11 @@ module.exports = function IndexModule(pb) {
             self.gatherData(function(err, data) {
                 
                 var articleService = new pb.ArticleService();
-                articleService.getMetaInfo(data.content[0], function(metaKeywords, metaDescription, metaTitle, metaThumbnail) {
-                    self.ts.registerLocal('meta_keywords', metaKeywords);
-                    self.ts.registerLocal('meta_desc', data.section.description || metaDescription);
-                    self.ts.registerLocal('meta_title', data.section.name || metaTitle);
-                    self.ts.registerLocal('meta_thumbnail', metaThumbnail);
+                articleService.getMetaInfo(data.content[0], function(err, meta) {
+                    self.ts.registerLocal('meta_keywords', meta.keywords);
+                    self.ts.registerLocal('meta_desc', data.section.description || meta.description);
+                    self.ts.registerLocal('meta_title', data.section.name || meta.title);
+                    self.ts.registerLocal('meta_thumbnail', meta.thumbnail);
                     self.ts.registerLocal('meta_lang', localizationLanguage);
                     self.ts.registerLocal('current_url', self.req.url);
                     self.ts.registerLocal('navigation', new pb.TemplateValue(data.nav.navigation, false));

--- a/plugins/portfolio/controllers/blog.js
+++ b/plugins/portfolio/controllers/blog.js
@@ -49,14 +49,14 @@ module.exports = function BlogModule(pb) {
         contentService.getSettings(function(err, contentSettings) {
             self.gatherData(function(err, data) {
                 var articleService = new pb.ArticleService();
-                articleService.getMetaInfo(data.content[0], function(metaKeywords, metaDescription, metaTitle, metaThumbnail) {
+                articleService.getMetaInfo(data.content[0], function(err, meta) {
 
                     self.ts.reprocess = false;
-                    self.ts.registerLocal('meta_keywords', metaKeywords);
-                    self.ts.registerLocal('meta_desc', data.section.description || metaDescription);
-                    self.ts.registerLocal('meta_title', data.section.name || metaTitle);
+                    self.ts.registerLocal('meta_keywords', meta.keywords);
+                    self.ts.registerLocal('meta_desc', data.section.description || meta.description);
+                    self.ts.registerLocal('meta_title', data.section.name || meta.title);
                     self.ts.registerLocal('meta_lang', localizationLanguage);
-                    self.ts.registerLocal('meta_thumbnail', metaThumbnail);
+                    self.ts.registerLocal('meta_thumbnail', meta.thumbnail);
                     self.ts.registerLocal('current_url', self.req.url);
                     self.ts.registerLocal('navigation', new pb.TemplateValue(data.nav.navigation, false));
                     self.ts.registerLocal('account_buttons', new pb.TemplateValue(data.nav.accountButtons, false));


### PR DESCRIPTION
Updating the signature of the callback passed to getMetaInfo(), in the themes that are using it, to work with the new version.