### PR TITLE
Fixes #600. Provides a fix for crashing home page.

### DIFF
--- a/include/service/entities/article_service.js
+++ b/include/service/entities/article_service.js
@@ -476,7 +476,17 @@ module.exports = function ArticleServiceModule(pb) {
      */
     ArticleService.prototype.getMetaInfo = function(article, cb) {
         if (util.isNullOrUndefined(article)) {
-            return cb(new Error('The article parameter cannot be null'));
+            return cb(
+                new Error('The article parameter cannot be null'),
+                
+                //provided for backward compatibility
+                {
+                    title: '',
+                    description: '',
+                    thumbnail: '',
+                    keywords: []
+                }
+            );
         }
         
         //compile the tasks necessary to gather the meta info


### PR DESCRIPTION
The index controller does not properly handle errors and does not properly check for null or undefined indices in the list of articles it is provided.  When it passes a null or undefined value the meta info is gathering is skipped causing a failure when the callback is returned and the error is not handled.