### PR TITLE
Fixes #603. Provides meaningful error message for Mongo connection failure

### DIFF
--- a/include/dao/db_manager.js
+++ b/include/dao/db_manager.js
@@ -86,7 +86,8 @@ module.exports = function DBManagerModule(pb) {
 
                 self.authenticate(pb.config.db.authentication, db, function(err, didAuthenticate) {
                     if (util.isError(err)) {
-                        return cb(err);
+                        var message = err.name + ': ' + err.message;
+                        return cb(new Error(message));
                     }
                     else if (didAuthenticate !== true && didAuthenticate !== null) {
                         return cb(new Error("Failed to authenticate to db "+name+": "+util.inspect(didAuthenticate)));
@@ -102,7 +103,7 @@ module.exports = function DBManagerModule(pb) {
         };
 
         /**
-         *
+         * 
          * @method authenticate
          * @param {Object} auth
          * @param {Db} db

--- a/include/dao/db_manager.js
+++ b/include/dao/db_manager.js
@@ -80,7 +80,8 @@ module.exports = function DBManagerModule(pb) {
             var self = this;
             mongo.connect(dbURL, options, function(err, db){
                 if (err) {
-                    return cb(err);
+                    var message = err.name + ': ' + err.message + ' - ' + dbURL + '\nIs your instance running?';
+                    return cb(new Error(message));
                 }
 
                 self.authenticate(pb.config.db.authentication, db, function(err, didAuthenticate) {


### PR DESCRIPTION
The code now produces an error message similar to:

```
Error: MongoError: connect ECONNREFUSED - mongodb://localhost:27017/pencilblue
Is your instance running?
    at code/pencilblue/include/dao/db_manager.js:84:31
    at code/pencilblue/node_modules/mongodb/lib/mongo_client.js:236:20
    at code/pencilblue/node_modules/mongodb/lib/db.js:197:14
    at null.<anonymous> (code/pencilblue/node_modules/mongodb/lib/server.js:226:9)
    at g (events.js:199:16)
    at emit (events.js:110:17)
    at null.<anonymous> (code/pencilblue/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:238:68)
    at g (events.js:199:16)
    at emit (events.js:110:17)
    at null.<anonymous> (code/pencilblue/node_modules/mongodb/node_modules/mongodb-core/lib/connection/pool.js:77:12)
Override file [code/pencilblue/config.js] will be applied.
2015-05-14T00:08:52.047Z - info: [5] SystemStartup: Log Level is: info
code/pencilblue/node_modules/mongodb/lib/server.js:228
        process.nextTick(function() { throw err; })
```