### PR TITLE
Fix for timestamp settings property duplication

### DIFF
--- a/include/content.js
+++ b/include/content.js
@@ -109,7 +109,7 @@ module.exports = function ContentServiceModule(pb) {
             twoDigitDate: contentSettings.two_digit_date,
             displayTime: contentSettings.display_hours_minutes,
             timeFormat: contentSettings.time_format,
-            twoDigitDate: contentSettings.two_digit_time,
+            twoDigitTime: contentSettings.two_digit_time,
             ls: ls
         };
         return ContentService.getTimestampText(options);


### PR DESCRIPTION
The setting value for two digit date was being incorrectly set to the two digit time setting value on duplication of the property. This was also preventing the two digit time setting from being set correctly.