### PR TITLE
0.5.0 localization fix

### DIFF
--- a/include/localization.js
+++ b/include/localization.js
@@ -282,6 +282,8 @@ module.exports = function LocalizationModule(pb) {
         if (!pb.validation.isNonEmptyStr(locale, true)) {
             return null;
         }
+        if(locale && locale.indexOf('_')<0)
+            locale = locale.replace('-','_');
         return Localization.storage[locale.toLowerCase()] || null;
     };
 


### PR DESCRIPTION
I hope that this will go to the CBDR branch of 0.5.0 and not the pencilblue version of that branch.  

This should fix the localization issue:
Localization service expected the locale to be in the form language_countrycode, however when loading from the files they come iin as language-country code.  When the localization service searched through its record of supported languages, it could not find en-us due to the fact that its storage object had the id en_us.

The fix adds an if-statement that converts en-us to en_us (works for any language/country code combination)