### PR TITLE
Serves an error for an invalid hostname

### DIFF
--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -653,7 +653,7 @@ module.exports = function RequestHandlerModule(pb) {
         //set the session
         this.session = session;
 
-        //set the site -- how do we handle improper sites here?
+        //set the site
         this.siteObj = RequestHandler.sites[this.hostname];
 
         if (!this.siteObj) {

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -654,8 +654,15 @@ module.exports = function RequestHandlerModule(pb) {
         this.session = session;
 
         //set the site -- how do we handle improper sites here?
-        this.siteObj = RequestHandler.sites[this.hostname] ? 
-            RequestHandler.sites[this.hostname] : this.serve404();
+        this.siteObj = RequestHandler.sites[this.hostname];
+
+        if (!this.siteObj) {
+            var hostnameErr = new Error("The host (" + this.hostname + ") has not been registered with a site. In single site mode, you must use your site root (" + pb.config.siteRoot + ").");
+            pb.log.error(hostnameErr);
+            this.serveError(hostnameErr);
+            return;
+        }
+
         this.site = this.siteObj.uid;
         this.siteName = this.siteObj.displayName;
         //find the controller to hand off to


### PR DESCRIPTION
Serves an error in the request handler when the request host is not registered or is not the siteroot.