### PR TITLE
Bugfix for AdminNavigation.buildNavigation()

### DIFF
--- a/include/admin_navigation.js
+++ b/include/admin_navigation.js
@@ -286,7 +286,7 @@ module.exports = function AdminNavigationModule(pb) {
 
 
             if (!util.isArray(nav.children)) {
-                navigation[i].children = [];
+                nav.children = [];
             }
             util.arrayPushAll(children, nav.children);
         });


### PR DESCRIPTION
I ended up in an exception when trying to add child navigation items using addChild(). The exception was thrown when the second child item was added.

    pb.AdminNavigation.add({
      id: TOP_MENU,
      title: 'Club manager',
      icon: 'cog',
      href: '/club-manager/admin',
      access: pb.SecurityService.ACCESS_EDITOR,
    }); 

    // Add management to navigation
    pb.AdminNavigation.addChild(TOP_MENU, {
      id: 'club-manager-management',
      title: 'Management',
      icon: 'cogs',
      href: '/club-manager/admin',
      access: pb.SecurityService.ACCESS_EDITOR
    });

    // Add match reports to navigation
    pb.AdminNavigation.addChild(TOP_MENU, {
      id: 'club-manager-match-report',
      title: 'Match reports',
      icon: 'file-o',
      href: '/club-manager/admin/match-report',
      access: pb.SecurityService.ACCESS_EDITOR     
    }); 
