### PR TITLE
Stop customObjectService.fetchChildren call if custom object type is not found.

### DIFF
--- a/include/service/entities/custom_object_service.js
+++ b/include/service/entities/custom_object_service.js
@@ -358,9 +358,10 @@ module.exports = function CustomObjectServiceModule(pb) {
 
         //make sure we have the type for the object passed in
         getCustObjType(custObjType, function(err, custObjType) {
-            if (util.isError(err)) {
+            if (util.isError(err) || util.isNullOrUndefined(custObjType)) {
                return cb(err);
             }
+
             var tasks = util.getTasks(Object.keys(custObjType.fields), function(fieldNames, i) {
                 return function(callback) {
 


### PR DESCRIPTION
Giving an invalid custom object id to customObjectService.fetchChildren results in a fields-property being read from a null object, thus throwing an error. 
```
var tasks = util.getTasks(Object.keys(custObjType.fields), function(fieldNames, i) {
```
where custObjType is null.

I was giving the ID of the custom object as a string instead of the ID of the custom object type for the fetchChildren(). 