### PR TITLE
Fix error after save of new article or page

### DIFF
--- a/plugins/pencilblue/templates/angular/admin/content/articles/article_form.html
+++ b/plugins/pencilblue/templates/angular/admin/content/articles/article_form.html
@@ -69,11 +69,11 @@
 						$scope.successMessage = 'SUCCESS';
 						$scope.saving = false;
 
-						if(!result.data._id) {
+						if(!result._id) {
 							$window.location = '/admin/content/articles';
 							return;
 						}
-						$window.location = '/admin/content/articles/' + result.data._id.toString();
+						$window.location = '/admin/content/articles/' + result._id.toString();
 					})
 					.error(function(error, status) {
 						$scope.errorMessage = error.message;

--- a/plugins/pencilblue/templates/angular/admin/content/pages/page_form.html
+++ b/plugins/pencilblue/templates/angular/admin/content/pages/page_form.html
@@ -63,7 +63,7 @@
                     .success(function(result) {
                         $scope.successMessage = 'SUCCESS';
                         $scope.saving = false;
-                        $window.location = '/admin/content/pages/' + result.data._id.toString();
+                        $window.location = '/admin/content/pages/' + result._id.toString();
                     })
                     .error(function(error, status) {
                         $scope.errorMessage = error.message;

--- a/plugins/portfolio/templates/angular/admin/content/pages/page_form.html
+++ b/plugins/portfolio/templates/angular/admin/content/pages/page_form.html
@@ -64,7 +64,7 @@
                     .success(function(result) {
                         $scope.successMessage = 'SUCCESS';
                         $scope.saving = false;
-                        $window.location = '/admin/content/pages/' + result.data._id.toString();
+                        $window.location = '/admin/content/pages/' + result._id.toString();
                     })
                     .error(function(error, status) {
                         $scope.errorMessage = error.message;


### PR DESCRIPTION
This fixes a bug due to the change in API end-points for saving articles and pages (my last pull request). The _id check was no longer occurring properly, so the page wasn't reloading after the initial save of a new article.