### PR TITLE
Allow configuration of media root URL

### DIFF
--- a/include/config.js
+++ b/include/config.js
@@ -354,6 +354,11 @@ Configuration.getBaseConfig = function(multisite) {
             provider: 'fs',
             parent_dir: 'public',
 
+            //The root media URL.  Example values: '//cdn.mydomain.com' or
+            //'http://example-bucket.s3-website-us-east-1.amazonaws.com'.  Use this
+            //if media is served from a domain other than the site root.
+            urlRoot: '',
+
             //The maximum size of media files that can be uploaded to the server in
             //bytes
             max_upload_size: 2 * 1024 * 1024
@@ -459,6 +464,11 @@ Configuration.mergeWithBase = function(overrides) {
     //special check to ensure that there is no ending slash on the site root
     if (config.siteRoot.lastIndexOf('/') === (config.siteRoot.length - 1)) {
         config.siteRoot = config.siteRoot.substring(0, config.siteRoot.length - 1);
+    }
+
+    //special check to ensure that there is no ending slash on the media root
+    if (config.media.urlRoot.lastIndexOf('/') === (config.media.urlRoot.length - 1)) {
+        config.media.urlRoot = config.media.urlRoot.substring(0, config.media.urlRoot.length - 1);
     }
     
 	return config;

--- a/include/service/media/renderers/audio_media_renderer.js
+++ b/include/service/media/renderers/audio_media_renderer.js
@@ -243,7 +243,7 @@ module.exports = function AudioMediaRendererModule(pb) {
      * represented by the media Id
      */
     AudioMediaRenderer.getEmbedUrl = function(mediaId) {
-        return mediaId;
+        return BaseMediaRenderer.getEmbedUrl(mediaId);
     };
 
     /**

--- a/include/service/media/renderers/base_media_renderer.js
+++ b/include/service/media/renderers/base_media_renderer.js
@@ -61,6 +61,19 @@ module.exports = function BaseMediaRenderer(pb) {
     };
 
     /**
+     * Retrieves the source URI that will be used when generating the rendering.
+     * This base implementation prepends the configured media urlRoot value to the media URI.
+     * @static
+     * @method getEmbedUrl
+     * @param {String} mediaId The unique (only to the type) media identifier
+     * @return {String} A properly formatted URI string that points to the resource
+     * represented by the media Id
+     */
+    BaseMediaRenderer.getEmbedUrl = function(mediaId) {
+        return pb.UrlService.urlJoin(pb.config.media.urlRoot, mediaId);
+    };
+
+    /**
      * Generates an attribute string from a hash of key/value pairs
      * @static
      * @method getAttributeStr

--- a/include/service/media/renderers/image_media_renderer.js
+++ b/include/service/media/renderers/image_media_renderer.js
@@ -225,7 +225,7 @@ module.exports = function ImageMediaRendererModule(pb) {
      * represented by the media Id
      */
     ImageMediaRenderer.getEmbedUrl = function(mediaId) {
-        return mediaId;
+        return BaseMediaRenderer.getEmbedUrl(mediaId);
     };
 
     /**

--- a/include/service/media/renderers/pdf_media_renderer.js
+++ b/include/service/media/renderers/pdf_media_renderer.js
@@ -236,7 +236,7 @@ module.exports = function(pb) {
      * represented by the media Id
      */
     PdfMediaRenderer.getEmbedUrl = function(mediaId) {
-        return mediaId;
+        return BaseMediaRenderer.getEmbedUrl(mediaId);
     };
 
     /**

--- a/include/service/media/renderers/video_media_renderer.js
+++ b/include/service/media/renderers/video_media_renderer.js
@@ -246,7 +246,7 @@ module.exports = function VideoMediaRendererModule(pb) {
      * represented by the media Id
      */
     VideoMediaRenderer.getEmbedUrl = function(mediaId) {
-        return mediaId;
+        return BaseMediaRenderer.getEmbedUrl(mediaId);
     };
 
     /**

--- a/plugins/pencilblue/controllers/admin/site_settings/configuration.js
+++ b/plugins/pencilblue/controllers/admin/site_settings/configuration.js
@@ -48,6 +48,7 @@ module.exports = function(pb) {
             var config = {
                 siteName: self.siteObj.displayName,
                 siteRoot: self.siteObj.hostname,
+                mediaRoot: pb.config.media.urlRoot ? pb.config.media.urlRoot : self.siteObj.hostname,
                 documentRoot: pb.config.docRoot,
                 siteIP: pb.config.siteIP,
                 sitePort: pb.config.sitePort,

--- a/plugins/pencilblue/templates/admin/site_settings/configuration.html
+++ b/plugins/pencilblue/templates/admin/site_settings/configuration.html
@@ -15,6 +15,10 @@
                     <td ng-bind="config.siteRoot"></td>
                 </tr>
                 <tr>
+                    <td><b>^loc_MEDIA_ROOT^</b></td>
+                    <td ng-bind="config.mediaRoot"></td>
+                </tr>
+                <tr>
                     <td><b>^loc_DOCUMENT_ROOT^</b></td>
                     <td ng-bind="config.documentRoot"></td>
                 </tr>

--- a/public/localization/de-DE.js
+++ b/public/localization/de-DE.js
@@ -460,6 +460,7 @@ module.exports = {
         EDIT_CONFIGURATION: 'Um die Konfiguration zu bearbeiten, müssen die die Datei "config.json" im Root-Verzeichnis anlegen.',
         SITE_NAME: 'Name der Site',
         SITE_ROOT: 'Root-Verzeichnis der Site',
+        MEDIA_ROOT: 'Root-Verzeichnis der Medientyp',
         DOCUMENT_ROOT: 'Basisverzeichnis für Dokumente',
         IP_ADDRESS: 'IP Adresse',
         PORT: 'Port',

--- a/public/localization/en-US.js
+++ b/public/localization/en-US.js
@@ -437,6 +437,7 @@ module.exports = {
         EDIT_CONFIGURATION: 'To edit the configuration, create a config.json file in the root directory',
         SITE_NAME: 'Site name',
         SITE_ROOT: 'Site root',
+        MEDIA_ROOT: 'Media root',
         DOCUMENT_ROOT: 'Document root',
         IP_ADDRESS: 'IP address',
         PORT: 'Port',

--- a/public/localization/es-ES.js
+++ b/public/localization/es-ES.js
@@ -436,6 +436,7 @@ module.exports = {
         EDIT_CONFIGURATION: 'Para cambiar la configuración, crea un archivo config.json en el directorio raíz.',
         SITE_NAME: 'Nombre del sitio',
         SITE_ROOT: 'Raíz del sitio',
+        MEDIA_ROOT: 'Raíz del multimedia',
         DOCUMENT_ROOT: 'Document root',
         IP_ADDRESS: 'Dirección IP',
         PORT: 'Puerto',

--- a/public/localization/fr-FR.js
+++ b/public/localization/fr-FR.js
@@ -437,6 +437,7 @@ module.exports = {
         EDIT_CONFIGURATION: 'Pour éditer la configuration, créer un fichier config.json dans le répertoire racine',
         SITE_NAME: 'Nom du site',
         SITE_ROOT: 'Racine du site',
+        MEDIA_ROOT: 'Racine du média',
         DOCUMENT_ROOT: 'Document racine',
         IP_ADDRESS: 'Adresse IP',
         PORT: 'Port',

--- a/public/localization/pl-PL.js
+++ b/public/localization/pl-PL.js
@@ -439,6 +439,7 @@ module.exports = {
         EDIT_CONFIGURATION: 'Aby zedytować ustawienia stwórz plik config.json w katalogu głównym',
         SITE_NAME: 'Nazwa strony',
         SITE_ROOT: 'Katalog główny strony',
+        MEDIA_ROOT: 'Korzeń mediów',
         DOCUMENT_ROOT: 'Document root',
         IP_ADDRESS: 'Adres IP',
         PORT: 'Port',

--- a/public/localization/pt-BR.js
+++ b/public/localization/pt-BR.js
@@ -437,6 +437,7 @@ module.exports = {
         EDIT_CONFIGURATION: 'Para editar as configurações, crie um config.json na raiz do diretório',
         SITE_NAME: 'Nome do site',
         SITE_ROOT: 'Raiz do site',
+        MEDIA_ROOT: 'Raiz do mídia',
         DOCUMENT_ROOT: 'Raiz do documento',
         IP_ADDRESS: 'Endereço IP',
         PORT: 'Porta',

--- a/public/localization/ro-RO.js
+++ b/public/localization/ro-RO.js
@@ -430,6 +430,7 @@ module.exports = {
         EDIT_CONFIGURATION: 'Pentru a edita configurarea creaza un fisier config.json in folderul radacina',
         SITE_NAME: 'Nume sit',
         SITE_ROOT: 'Radacina sit',
+        MEDIA_ROOT: 'Radacina media',
         DOCUMENT_ROOT: 'Radacina document',
         IP_ADDRESS: 'Adresa IP',
         PORT: 'Port',

--- a/test/include/service/entities/content/article_renderer_tests.js
+++ b/test/include/service/entities/content/article_renderer_tests.js
@@ -42,7 +42,7 @@ describe('ArticleRenderer', function() {
             var service = new ArticleRenderer();
             service.formatLayoutForReadMore(article, context);
 
-            var count = (article.article_layout.match(/Read More/g)).length
+            var count = (article.article_layout.match(/Read More/g)).length;
             count.should.eql(1);
         });
 

--- a/test/include/service/entities/content/article_service_v2_tests.js
+++ b/test/include/service/entities/content/article_service_v2_tests.js
@@ -15,7 +15,7 @@ describe('ArticleServiceV2', function() {
       var article2 = getArticle();
 
       // Set expected date to the parsed version of the date being passed to the service
-      article2.publish_date = pb.BaseObjectService.getDate(article2.publish_date)
+      article2.publish_date = pb.BaseObjectService.getDate(article2.publish_date);
 
       ArticleServiceV2.format({data: article}, function() {});
       should.deepEqual(article, article2);

--- a/test/include/service/entities/content/page_service_tests.js
+++ b/test/include/service/entities/content/page_service_tests.js
@@ -15,7 +15,7 @@ describe('PageService', function() {
       var page2 = getPage();
 
       // Set expected date to the parsed version of the date being passed to the service
-      page2.publish_date = pb.BaseObjectService.getDate(page2.publish_date)
+      page2.publish_date = pb.BaseObjectService.getDate(page2.publish_date);
 
       PageService.format({data: page}, function() {});
       should.deepEqual(page, page2);

--- a/test/include/service/media/renderers/media_root_tests.js
+++ b/test/include/service/media/renderers/media_root_tests.js
@@ -1,0 +1,128 @@
+//depedencies
+var should = require('should');
+
+
+describe('BaseMediaRenderer', function() {
+  describe('BaseMediaRenderer.getEmbedUrl', function () {
+    it('should not modify media id', function () {
+      var pb = {config: {siteRoot: 'http://www.test.com', media: {urlRoot: ''}}};
+      pb.UrlService = require('../../../../../include/service/entities/url_service.js')(pb);
+      var BaseMediaRenderer = require('../../../../../include/service/media/renderers/base_media_renderer.js')(pb);
+
+      var url = BaseMediaRenderer.getEmbedUrl("/media/01/02/test.png");
+      url.should.eql("/media/01/02/test.png");
+    });
+
+    it('should prepend media root', function () {
+      var pb = {config: {siteRoot: 'http://www.test.com', media: {urlRoot: 'http://cdn.test.com'}}};
+      pb.UrlService = require('../../../../../include/service/entities/url_service.js')(pb);
+      var BaseMediaRenderer = require('../../../../../include/service/media/renderers/base_media_renderer.js')(pb);
+
+      var url = BaseMediaRenderer.getEmbedUrl("/media/01/02/test.png");
+      url.should.eql("http://cdn.test.com/media/01/02/test.png");
+    });
+  });
+});
+
+describe('ImageMediaRenderer', function() {
+  describe('ImageMediaRenderer.getEmbedUrl', function () {
+    it('should prepend media root', function () {
+      var pb = {
+        config: {siteRoot: 'http://www.test.com', media: {urlRoot: 'http://cdn.test.com'}},
+        media: {renderers: {}}
+      };
+      pb.UrlService = require('../../../../../include/service/entities/url_service.js')(pb);
+      pb.media.renderers.BaseMediaRenderer = require('../../../../../include/service/media/renderers/base_media_renderer.js')(pb);
+      var ImageMediaRenderer = require('../../../../../include/service/media/renderers/image_media_renderer.js')(pb);
+
+      var url = ImageMediaRenderer.getEmbedUrl("/media/01/02/test.png");
+      url.should.eql("http://cdn.test.com/media/01/02/test.png");
+    });
+  });
+});
+
+describe('AudioMediaRenderer', function() {
+  describe('AudioMediaRenderer.getEmbedUrl', function () {
+    it('should prepend media root', function () {
+      var pb = {
+        config: {siteRoot: 'http://www.test.com', media: {urlRoot: 'http://cdn.test.com'}},
+        media: {renderers: {}}
+      };
+      pb.UrlService = require('../../../../../include/service/entities/url_service.js')(pb);
+      pb.media.renderers.BaseMediaRenderer = require('../../../../../include/service/media/renderers/base_media_renderer.js')(pb);
+      var AudioMediaRenderer = require('../../../../../include/service/media/renderers/audio_media_renderer.js')(pb);
+
+      var url = AudioMediaRenderer.getEmbedUrl("/media/01/02/test.mp3");
+      url.should.eql("http://cdn.test.com/media/01/02/test.mp3");
+    });
+  });
+});
+
+describe('PdfMediaRenderer', function() {
+  describe('PdfMediaRenderer.getEmbedUrl', function () {
+    it('should prepend media root', function () {
+      var pb = {
+        config: {siteRoot: 'http://www.test.com', media: {urlRoot: 'http://cdn.test.com'}},
+        media: {renderers: {}}
+      };
+      pb.UrlService = require('../../../../../include/service/entities/url_service.js')(pb);
+      pb.media.renderers.BaseMediaRenderer = require('../../../../../include/service/media/renderers/base_media_renderer.js')(pb);
+      var PdfMediaRenderer = require('../../../../../include/service/media/renderers/pdf_media_renderer.js')(pb);
+
+      var url = PdfMediaRenderer.getEmbedUrl("/media/01/02/test.pdf");
+      url.should.eql("http://cdn.test.com/media/01/02/test.pdf");
+    });
+  });
+});
+
+describe('VideoMediaRenderer', function() {
+  describe('VideoMediaRenderer.getEmbedUrl', function () {
+    it('should prepend media root', function () {
+      var pb = {
+        config: {siteRoot: 'http://www.test.com', media: {urlRoot: 'http://cdn.test.com'}},
+        media: {renderers: {}}
+      };
+      pb.UrlService = require('../../../../../include/service/entities/url_service.js')(pb);
+      pb.media.renderers.BaseMediaRenderer = require('../../../../../include/service/media/renderers/base_media_renderer.js')(pb);
+      var VideoMediaRenderer = require('../../../../../include/service/media/renderers/video_media_renderer.js')(pb);
+
+      var url = VideoMediaRenderer.getEmbedUrl("/media/01/02/test.webm");
+      url.should.eql("http://cdn.test.com/media/01/02/test.webm");
+    });
+  });
+});
+
+describe('VideoMediaRenderer', function() {
+  describe('VideoMediaRenderer.getEmbedUrl', function () {
+    it('should prepend media root', function () {
+      var pb = {
+        config: {siteRoot: 'http://www.test.com', media: {urlRoot: 'http://cdn.test.com'}},
+        media: {renderers: {}}
+      };
+      pb.UrlService = require('../../../../../include/service/entities/url_service.js')(pb);
+      pb.media.renderers.BaseMediaRenderer = require('../../../../../include/service/media/renderers/base_media_renderer.js')(pb);
+      var VideoMediaRenderer = require('../../../../../include/service/media/renderers/video_media_renderer.js')(pb);
+
+      var url = VideoMediaRenderer.getEmbedUrl("/media/01/02/test.webm");
+      url.should.eql("http://cdn.test.com/media/01/02/test.webm");
+    });
+  });
+});
+
+describe('YouTubeMediaRenderer', function() {
+  describe('YouTubeMediaRenderer.getEmbedUrl', function () {
+    it('should not prepend media root', function () {
+      var pb = {
+        config: {siteRoot: 'http://www.test.com', media: {urlRoot: 'http://cdn.test.com'}},
+        media: {renderers: {}}
+      };
+      pb.UrlService = require('../../../../../include/service/entities/url_service.js')(pb);
+      pb.media.renderers.BaseMediaRenderer = require('../../../../../include/service/media/renderers/base_media_renderer.js')(pb);
+      var YouTubeMediaRenderer = require('../../../../../include/service/media/renderers/youtube_media_renderer.js')(pb);
+
+      var url = YouTubeMediaRenderer.getEmbedUrl("mediaID");
+      url.should.startWith("//www.youtube.com");
+      url.indexOf(pb.config.media.urlRoot).should.eql(-1);
+    });
+  });
+});


### PR DESCRIPTION
This change allows you to configure the root URL to be used for media uploaded by PencilBlue. This allows you to use a different subdomain like cdn.mydomain.com for media served by PencilBlue, which is often necessary for CDN caching of static resources. You can also use this in conjunction with a media provider like the s3-pencilblue plugin to send all media request traffic directly to your media storage server.

You don't need to re-upload media when you change the media root URL.

This change also displays the configured media root URL on the site settings page.