### PR TITLE
Fix for subnav pills failing to load on media list page

### DIFF
--- a/plugins/pencilblue/controllers/admin/content/media/manage_media.js
+++ b/plugins/pencilblue/controllers/admin/content/media/manage_media.js
@@ -63,20 +63,18 @@ module.exports = function(pb) {
     ManageMedia.prototype.getAngularObjects = function(mediaData, cb) {
         var self = this;
         pb.AdminSubnavService.getWithSite(SUB_NAV_KEY, self.ls, SUB_NAV_KEY, {site: self.site}, function(err, pills) {
+            //Log error. Don't return
+            if (util.isError(err)){
+                pills = [];
+                pb.log.error("ManageMedia: AdminSubnavService.getWithSite callback error. ERROR[%s]", err.stack);
+            }
+
             var angularObjects = pb.ClientJs.getAngularObjects(
                 {
                     navigation: pb.AdminNavigation.get(self.session, ['content', 'media'], self.ls, self.site),
-                    pills: [],
+                    pills: pills,
                     media: pb.MediaService.formatMedia(mediaData)
                 });
-            //Log error. Don't return
-            if (util.isError(err)){
-                pb.log.error("ManageMedia: AdminSubnavService.getWithSite callback error. ERROR[%s]", err.stack);
-            }
-            //Only populate pills if we didn't fail
-            else {
-                angularObjects.pills = pills;
-            }
             //TODO: err first arg for style. User experience error when no pills?
             cb(angularObjects);
         });


### PR DESCRIPTION
I copied the logic from manage_articles.js to get this working. The previous code was trying to set the `pills` attribute on the variable `angularObjects` which is a String, resulting in the nav buttons for adding new media never displaying.