### PR TITLE
Updates to support media file uploads that result in remote absolute url locations

### DIFF
--- a/include/service/entities/media_service.js
+++ b/include/service/entities/media_service.js
@@ -238,8 +238,12 @@ module.exports = function MediaServiceModule(pb) {
      */
     MediaService.prototype.setContent = function(fileDataStrOrBuff, fileName, cb) {
         var mediaPath = MediaService.generateMediaPath(fileName);
-        this.provider.set(fileDataStrOrBuff, mediaPath, function(err, result) {
-            cb(err, { mediaPath: mediaPath, result: result});
+        this.provider.set(fileDataStrOrBuff, mediaPath, function(err, remoteURL, result) {
+            if (util.isBoolean(remoteURL)) {		
+              cb(err, { mediaPath: mediaPath, result: result});		
+            } else {		
+              cb(err, { mediaPath: remoteURL, result: result});		
+            }
         });
     };
 
@@ -252,8 +256,12 @@ module.exports = function MediaServiceModule(pb) {
      */
     MediaService.prototype.setContentStream = function(stream, fileName, cb) {
         var mediaPath = MediaService.generateMediaPath(fileName);
-        this.provider.setStream(stream, mediaPath, function(err, result) {
-            cb(err, { mediaPath: mediaPath, result: result});
+        this.provider.setStream(stream, mediaPath, function(err, remoteURL, result) {
+            if (util.isBoolean(remoteURL)) {		
+              cb(err, { mediaPath: mediaPath, result: result});		
+            } else {		
+              cb(err, { mediaPath: remoteURL, result: result});		
+            }
         });
     };
 

--- a/plugins/pencilblue/controllers/actions/admin/content/media/delete_media.js
+++ b/plugins/pencilblue/controllers/actions/admin/content/media/delete_media.js
@@ -77,7 +77,7 @@ module.exports = function(pb) {
     };
 
     DeleteMediaController.prototype.removeLocal = function(media, mservice, cb) {
-        if (!media.is_file) {
+        if (!media.is_file && media.location.indexOf('http') !== 0 && media.location.indexOf('//') !== 0) {
             return cb();
         }
         mservice.deleteContentByPath(media.location, cb);


### PR DESCRIPTION
Great project!  I've been building a PencilBlue Media Provider Plugin for the Openstack Swift Bluemix Object Storage v1 service.   After trying a few approaches, I realized with the current code base that a file upload didn't seem able to return a remote HTTP url location.  My media provider takes the content stream from the file upload and "puts" the content into the remote system. This results in a mediaPath value that is an absolute HTTP URL.  This is sort of a hybrid of the Media URL Link usecase and the local file upload use case.  

Without this PR, my provider was always embedding a media entry that was treated as a relative file on the server rather than a remote linked absolute url resource.  Please advise if there is a better way to approach the issue.  I've tried to maintain backwards compatibility by falling back to the default behavior if the new remoteURL argument is a boolean.  