### PR TITLE
Adding missing semicolon to HTML entity

### DIFF
--- a/include/service/entities/content/article_renderer.js
+++ b/include/service/entities/content/article_renderer.js
@@ -363,7 +363,7 @@ module.exports = function(pb) {
      * @return {String}
      */
     ArticleRenderer.prototype.getReadMoreSpan = function(content, anchorContent) {
-        return '&nbsp<span class="read_more">' + this.getReadMoreLink(content, anchorContent) + '</span>';
+        return '&nbsp;<span class="read_more">' + this.getReadMoreLink(content, anchorContent) + '</span>';
     };
 
     /**


### PR DESCRIPTION
The `&nbsp` HTML entity in the read more link was missing the semicolon. This was causing rendering issues in system generated emails.