### PR TITLE
Issue #803 if result type is boolean and it's been set to false

### DIFF
--- a/include/service/simple_layered_service.js
+++ b/include/service/simple_layered_service.js
@@ -65,7 +65,7 @@ module.exports = function SimpleLayeredServiceModule(pb) {
                         return;
                     }
 
-                    if (result) {
+                    if (result || (typeof result === 'boolean' && result === false)) {
                         resultNotFound = false;
                         entity         = result;
                     }

--- a/plugins/pencilblue/controllers/actions/admin/site_settings/configuration.js
+++ b/plugins/pencilblue/controllers/actions/admin/site_settings/configuration.js
@@ -43,7 +43,7 @@ module.exports = function(pb) {
                 if(util.isError(data)) {
                     cb({
                         code: 500,
-                        content: pb.BaseController.apiResponse(pb.BaseController.API_FAILURE, self.ls.get('ERROR_SAVING'), result)
+                        content: pb.BaseController.apiResponse(pb.BaseController.API_FAILURE, self.ls.get('ERROR_SAVING'), data)
                     });
                     return;
                 }


### PR DESCRIPTION
I've noticed that in the get prototype of SimpleLayeredService, if the result value is something boolean and false the code will not reach line 69 so the entity will be sent as null while it's not. To catch it I check the type of result and if it's boolean and false it will consider it as an answer and set it as the entity. I think it might be a good idea to start a community forum, a slack or something so we can discuss more of issues and how to handle them and start writing some frontend testing too.