### PR TITLE
Fix #863 use typeId

### DIFF
--- a/include/service/entities/custom_object_service.js
+++ b/include/service/entities/custom_object_service.js
@@ -991,7 +991,7 @@ module.exports = function CustomObjectServiceModule(pb) {
             typeId = custObjType.toString();
         }
         var dao = new pb.DAO();
-        dao.delete({type: custObjType}, CustomObjectService.CUST_OBJ_COLL, cb);
+        dao.delete({type: typeId}, CustomObjectService.CUST_OBJ_COLL, cb);
     };
 
     CustomObjectService.prototype.typeExists = function(typeName, cb) {


### PR DESCRIPTION
typeId is declared but never used. I think the intention of declaring typeId is to use it in the delete query. So I replaced it with custObjType. Just I am not sure if I should change dao to siteQueryService or not.