### PR TITLE
Update custom_object_service.js

### DIFF
--- a/include/service/entities/custom_object_service.js
+++ b/include/service/entities/custom_object_service.js
@@ -577,7 +577,12 @@ module.exports = function CustomObjectServiceModule(pb) {
         }
 
         if (type) {
-            where.type = type;
+            var typeStr = type;
+            if (util.isObject(type)) {
+                typeStr = type[pb.DAO.getIdField()] + '';
+            }
+    
+            where.type = typeStr;
         }
 
         var self = this;


### PR DESCRIPTION
findByType and loadByName of CustomObjectService are quite related in purpose and seem to be similar in their interface. However, the interface here is inconsistant. FindByType currently accepts a "type" which can be either object or string. Whereas loadByName also has an attribute "type" but in this case only its 'string' form is accepted. 
How to get to the type object was quite obvious to me. How to find the right string on the other hand did cost me 2 hours of digging through the pb source code. This change should unify this behaviour. 
This change is untested. I did apply the solution to my problem in my plugin.