### PR TITLE
Plugin Init improvements

### DIFF
--- a/include/service/entities/plugin_service.js
+++ b/include/service/entities/plugin_service.js
@@ -1342,6 +1342,7 @@ module.exports = function PluginServiceModule(pb) {
                     var rootDirSatsified = checkPackageVersion(rootPackagePath);
 
                     if(!pluginDirSatisfied && !rootDirSatsified) {
+                        hasDependencies = false;
                         pb.log.warn('PluginService: Plugin %s has incorrect dependency version %s for %s', plugin.name, package.version, keys[i]);
                     }
 


### PR DESCRIPTION
Add cache for use in plugin initialization, add root node_modules path as a fallback for dependency check, and make use of details.json file for dependency checking instead of DB.  