### PR TITLE
BaseObjectService on insert fix

### DIFF
--- a/include/service/base_object_service.js
+++ b/include/service/base_object_service.js
@@ -537,7 +537,7 @@ module.exports = function(pb) {
         else {
             
             //we are creating a new object so pass it along
-            onObjectRetrieved(null, {});
+            onObjectRetrieved(null, dto);
         }
     };
     


### PR DESCRIPTION
Data being saved through base object service via insert is orphaned due to passing an empty object to onObjectRetrieved function 