### PR TITLE
Autosync plugin settings

### DIFF
--- a/include/config.js
+++ b/include/config.js
@@ -219,6 +219,7 @@ Configuration.getBaseConfig = function(multisite) {
         settings: {
             use_memory: true,
             use_cache: false,
+            autoSync: false,
 
             //The timeout specifies how long in milliseconds a setting will exist
             //in memory before being flushed.  A value of 0 indicates that the

--- a/include/service/entities/plugin_service.js
+++ b/include/service/entities/plugin_service.js
@@ -560,7 +560,7 @@ module.exports = function PluginServiceModule(pb) {
                 hashedSettings[settingName] = true;
                 if (settings[settingName] === undefined) {
                     discrepancy = true;
-                    formattedSettings.push({name: details.settings[i].name, value: details.settings[i].value});
+                    formattedSettings.push({name: settingName, value: details.settings[i].value});
                 }
                 else {
                     formattedSettings.push({name: settingName, value: settings[settingName]});

--- a/include/service/entities/plugin_service.js
+++ b/include/service/entities/plugin_service.js
@@ -1,19 +1,19 @@
 /*
-    Copyright (C) 2015  PencilBlue, LLC
+ Copyright (C) 2015  PencilBlue, LLC
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 //dependencies
 var fs      = require('fs');
@@ -538,6 +538,65 @@ module.exports = function PluginServiceModule(pb) {
      * existing settings for the plugin are deleted before the new settings are
      * persisted.
      *
+     * @method syncSettings
+     * @param details The details object to extract the settings from
+     * @param cb A callback that provides two parameters: cb(error, TRUE/FALSE).
+     * TRUE if the settings were successfully cleared and reloaded. FALSE if not.
+     */
+    PluginService.prototype.syncSettings = function(plugin, details, cb) {
+        var self = this;
+        this.getSettingsKV(plugin.dirName, function(err, settings) {
+            if (pb.util.isError(err) || !settings) {
+                pb.log.error("PluginService.syncSettings failed to load settings from plugin [" + plugin.dirName + "]");
+                return cb(null, true);
+            }
+            var discrepancy = false;
+            var hashedSettings = {};
+            var formattedSettings = [];
+
+            // Detect new settings
+            for (var i = 0; i < details.settings.length; i++) {
+                var settingName = details.settings[i].name;
+                hashedSettings[settingName] = true;
+                if (settings[settingName] === undefined) {
+                    discrepancy = true;
+                    formattedSettings.push({name: details.settings[i].name, value: details.settings[i].value});
+                }
+                else {
+                    formattedSettings.push({name: settingName, value: settings[settingName]});
+                }
+            }
+
+            // Detect deprecated settings if we haven't already detected a discrepancy
+            if (!discrepancy) {
+                for (var setting in settings) {
+                    if (!hashedSettings[setting]) {
+                        discrepancy = true;
+                        break;
+                    }
+                }
+            }
+
+            // If a plugin setting needs updating, save it off
+            if (discrepancy) {
+                self.resetSettings({uid: plugin.uid, settings: formattedSettings}, function(err, result) {
+                    if (pb.util.isError(err)) {
+                        pb.log.error("PluginService.syncSettings failed to save off updated settings for " + plugin.dirName);
+                    }
+                    cb(null, true);
+                });
+            }
+            else {
+                cb(null, true);
+            }
+        });
+    };
+
+    /**
+     * Loads the settings from a details object and persists them in the DB.  Any
+     * existing settings for the plugin are deleted before the new settings are
+     * persisted.
+     *
      * @method resetSettings
      * @param details The details object to extract the settings from
      * @param cb A callback that provides two parameters: cb(error, TRUE/FALSE).
@@ -574,64 +633,6 @@ module.exports = function PluginServiceModule(pb) {
                     cb(err, !util.isError(err));
                 });
             });
-        });
-    };
-
-    /**
-     * Loads the settings from a details object and persists them in the DB.  Any
-     * existing settings for the plugin are deleted before the new settings are
-     * persisted.
-     *
-     * @method syncSettings
-     * @param details The details object to extract the settings from
-     * @param cb A callback that provides two parameters: cb(error, TRUE/FALSE).
-     * TRUE if the settings were successfully cleared and reloaded. FALSE if not.
-     */
-    PluginService.prototype.syncSettings = function(plugin, details, cb) {
-        var self = this;
-        this.getSettingsKV(plugin.dirName, function(err, settings) {
-            if (pb.util.isError(err) || !settings) {
-                return cb(err);
-            }
-            var discrepancy = false;
-            var hashedSettings = {};
-            var formattedSettings = [];
-
-            // Detect new settings
-            for (var i = 0; i < details.settings.length; i++) {
-                var settingName = details.settings[i].name;
-                hashedSettings[settingName] = true;
-                if (settings[settingName] === undefined) {
-                    discrepancy = true;
-                    formattedSettings.push({name: details.settings[i].name, value: details.settings[i].value});
-                }
-                else {
-                    formattedSettings.push({name: settingName, value: settings[settingName]});
-                }
-            }
-
-            // Detect deprecated settings if we haven't already detected a discrepancy
-            if (!discrepancy) {
-                for (var setting in settings) {
-                    if (!hashedSettings[setting]) {
-                        discrepancy = true;
-                        break;
-                    }
-                }
-            }
-
-            // If a plugin setting needs updating, save it off
-            if (discrepancy) {
-                self.resetSettings({uid: plugin.uid, settings: formattedSettings}, function(err, result) {
-                    if (pb.util.isError(err)) {
-                        pb.log.error("PluginService.syncSettings failed to save off updated settings for " + plugin.dirName);
-                    }
-                    cb(null, !err);
-                });
-            }
-            else {
-                cb(null, true);
-            }
         });
     };
 
@@ -923,13 +924,13 @@ module.exports = function PluginServiceModule(pb) {
         var self  = this;
         var tasks = {
 
-             active: function(callback) {
-                 self.getActivePlugins(callback);
-             },
+            active: function(callback) {
+                self.getActivePlugins(callback);
+            },
 
-             inactive: function(callback) {
-                 self.getInactivePlugins(callback);
-             }
+            inactive: function(callback) {
+                self.getInactivePlugins(callback);
+            }
         };
         async.series(tasks, function(err, results) {
             if (util.isError(err)) {
@@ -1129,7 +1130,7 @@ module.exports = function PluginServiceModule(pb) {
         var details = null;
         var site = plugin.site || GLOBAL_SITE;
         var cached_plugin = PLUGIN_INIT_CACHE[plugin.uid] || null;
-        var autoSync = pb.config.settings.autoSync;
+        var autoSync = pb.config.settings.autoSync || false;
         var site_independant_tasks = [
             //load the details file
             function(callback) {
@@ -1138,11 +1139,9 @@ module.exports = function PluginServiceModule(pb) {
                 if(!cached_plugin || !cached_plugin.details) {
                     return PluginService.loadDetailsFile(PluginService.getDetailsPath(plugin.dirName), function (err, loadedDetails) {
                         details = loadedDetails;
-                        if (autoSync) {
+                        if (autoSync && !pb.util.isError(err) && details) {
                             var pluginService = new PluginService({site: site});
-                            pluginService.syncSettings(plugin, details, function(err, result){
-                                callback(null, true);
-                            });
+                            pluginService.syncSettings(plugin, details, callback);
                         }
                         else {
                             callback(err, !!details);
@@ -1214,6 +1213,16 @@ module.exports = function PluginServiceModule(pb) {
         ];
 
         var tasks   = [
+            // Sync plugin settings
+            function(callback) {
+                if (cached_plugin && cached_plugin.details && autoSync) {
+                    var pluginService = new PluginService({site: site});
+                    pluginService.syncSettings(plugin, cached_plugin.details, callback);
+                }
+                else {
+                    return callback(null, true);
+                }
+            },
 
             //register plugin & load main module
             function(callback) {
@@ -1646,7 +1655,7 @@ module.exports = function PluginServiceModule(pb) {
      * @return {Object} Service prototype
      */
     PluginService.prototype.getService = function(serviceName, pluginUid, site) {
-        pb.log.warn('PluginService: Instance function getService is deprecated. Use pb.PluginService.getService intead');
+        pb.log.warn('PluginService: Instance function getService is deprecated. Use pb.PluginService.getService instead: plugin:' + pluginUid + ' service:' + serviceName);
         try{
             return PluginService.getService(serviceName, pluginUid, site);
         }
@@ -2025,7 +2034,6 @@ module.exports = function PluginServiceModule(pb) {
         if (isError) {
             error = new Error("Faled to validate plugin details");
             error.validationErrors = errors;
-
             //log the validation errors
             errors.forEach(function(validationError) {
                 pb.log.error('PluginService:[%s] %s', details.uid, validationError);
@@ -2374,16 +2382,16 @@ module.exports = function PluginServiceModule(pb) {
         var name = util.format("IS_AVAILABLE_%s", command.pluginUid);
         var job  = new pb.PluginAvailableJob();
         job.setRunAsInitiator(false)
-        .init(name, command.jobId)
-        .setPluginUid(command.pluginUid)
-        .run(function(err, result) {
+            .init(name, command.jobId)
+            .setPluginUid(command.pluginUid)
+            .run(function(err, result) {
 
-            var response = {
-                error: err ? err.stack : undefined,
-                result: result ? true : false
-            };
-            pb.CommandService.getInstance().sendInResponseTo(command, response);
-        });
+                var response = {
+                    error: err ? err.stack : undefined,
+                    result: result ? true : false
+                };
+                pb.CommandService.getInstance().sendInResponseTo(command, response);
+            });
     };
 
     /**
@@ -2406,16 +2414,16 @@ module.exports = function PluginServiceModule(pb) {
         var name = util.format("INSTALL_DEPENDENCIES_%s", command.pluginUid);
         var job  = new pb.PluginDependenciesJob();
         job.setRunAsInitiator(false)
-        .init(name, command.jobId)
-        .setPluginUid(command.pluginUid)
-        .run(function(err, result) {
+            .init(name, command.jobId)
+            .setPluginUid(command.pluginUid)
+            .run(function(err, result) {
 
-            var response = {
-                error: err ? err.stack : undefined,
-                result: result ? true : false
-            };
-            pb.CommandService.getInstance().sendInResponseTo(command, response);
-        });
+                var response = {
+                    error: err ? err.stack : undefined,
+                    result: result ? true : false
+                };
+                pb.CommandService.getInstance().sendInResponseTo(command, response);
+            });
     };
 
     /**
@@ -2438,17 +2446,17 @@ module.exports = function PluginServiceModule(pb) {
         var name = util.format("INITIALIZE_PLUGIN_%s", command.pluginUid);
         var job  = new pb.PluginInitializeJob();
         job.setRunAsInitiator(false)
-        .init(name, command.jobId)
-        .setPluginUid(command.pluginUid)
-        .setSite(command.site)
-        .run(function(err, result) {
+            .init(name, command.jobId)
+            .setPluginUid(command.pluginUid)
+            .setSite(command.site)
+            .run(function(err, result) {
 
-            var response = {
-                error: err ? err.stack : undefined,
-                result: result ? true : false
-            };
-            pb.CommandService.getInstance().sendInResponseTo(command, response);
-        });
+                var response = {
+                    error: err ? err.stack : undefined,
+                    result: result ? true : false
+                };
+                pb.CommandService.getInstance().sendInResponseTo(command, response);
+            });
     };
 
     /**

--- a/include/service/entities/plugin_service.js
+++ b/include/service/entities/plugin_service.js
@@ -593,7 +593,7 @@ module.exports = function PluginServiceModule(pb) {
             if (pb.util.isError(err) || !settings) {
                 return cb(err);
             }
-            var discrepancy = true;
+            var discrepancy = false;
             var hashedSettings = {};
             var formattedSettings = [];
 
@@ -610,11 +610,13 @@ module.exports = function PluginServiceModule(pb) {
                 }
             }
 
-            // Detect deprecated settings
-            for (setting in settings) {
-                if (!hashedSettings[setting]) {
-                    discrepancy = true;
-                    break;
+            // Detect deprecated settings if we haven't already detected a discrepancy
+            if (!discrepancy) {
+                for (var setting in settings) {
+                    if (!hashedSettings[setting]) {
+                        discrepancy = true;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Creates a config setting: "autoSync" to compare plugin settings' details.json settings against the DB-loaded values. If a discrepancy is detected, the plugin is saved off.