### PR TITLE
fix offset not being passed to getPageArray

### DIFF
--- a/public/js/angular/services/paginate.js
+++ b/public/js/angular/services/paginate.js
@@ -13,7 +13,7 @@ angular.module('paginate', [])
 			}
 		}
 
-		var pages = this.getPageArray(limit, itemCount);
+		var pages = this.getPageArray(offset, limit, itemCount);
 
 		cb(items, pages);
 	};


### PR DESCRIPTION
The offset parameter is not being passed to getPageArray.  This is preventing it from returning the proper pages array, and activating the pagination buttons.