### PR TITLE
fixes #955 - generated URLs are safe

### DIFF
--- a/plugins/pencilblue/templates/angular/admin/content/articles/article_form.html
+++ b/plugins/pencilblue/templates/angular/admin/content/articles/article_form.html
@@ -168,11 +168,7 @@
 			});
 		};
 
-		$scope.generateUrl = function(text) {
-			if (text) {
-				return text.replace(/\s+/g, '-').toLowerCase();
-			}
-		};
+		^tmp_angular=admin=elements=generate_url^
 
 		$scope.getUrl = function() {
 			$scope.article.url = $scope.generateUrl($scope.article.headline);
@@ -184,7 +180,7 @@
 			.error(function(error, status) {
 				$scope.errorMessage = error.message;
 			});
-			
+
 			if($scope.article.url && $scope.article.url.length) {
 				$scope.urlGenerated = true;
 			} else {
@@ -195,10 +191,10 @@
 		$scope.$watch('article.url', function(newVal, oldVal) {
 			if (newVal !== oldVal) {
 				if($scope.article.url !== $scope.generateUrl($scope.article.headline)){
-	 			   $scope.urlGenerated = null;
-	 		   	}
+ 			  	$scope.urlGenerated = null;
+ 		   	}
 			}
-	   	});
+   	});
 
 		$('#publish_date').datetimepicker({format: 'm-d-Y H:i'});
 		$timeout($scope.saveArticleDraft, 30000);

--- a/plugins/pencilblue/templates/angular/admin/content/pages/page_form.html
+++ b/plugins/pencilblue/templates/angular/admin/content/pages/page_form.html
@@ -152,15 +152,11 @@
             });
         };
 
-        $scope.generateUrl = function(text) {
-			if (text) {
-				return text.replace(/\s+/g, '-').toLowerCase();
-			}
-		};
+        ^tmp_angular=admin=elements=generate_url^
 
 		$scope.getUrl = function() {
 			$scope.page.url = $scope.generateUrl($scope.page.headline);
-            
+
             $http.get('/api/url/exists_for?url=' + $scope.page.url + '&type=page&' + $scope.siteKey + '=' + $scope.site)
             .success(function(result) {
                 $scope.urlAvailable = !result.data;

--- a/plugins/pencilblue/templates/angular/admin/elements/generate_url.html
+++ b/plugins/pencilblue/templates/angular/admin/elements/generate_url.html
@@ -1,0 +1,3 @@
+$scope.generateUrl = function(text) {
+  return text ? text.replace(/\s+/g, '-').replace(/[^a-zA-Z0-9_-]/g, '') : null;
+};


### PR DESCRIPTION
Created an external template for the generateUrl function because the ^ of the regex was breaking the template service, and because it's duplicate code anyway.