### PR TITLE
Upgrading packages to highest level, tested by apimonkey

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,74 +1,74 @@
 {
-    "author": {
-        "name": "PencilBlue, LLC",
-        "email": "info@pencilblue.com"
+  "author": {
+    "name": "PencilBlue, LLC",
+    "email": "info@pencilblue.com"
+  },
+  "contributors": [
+    {
+      "name": "Blake Callens"
     },
-    "contributors": [
-        {
-            "name": "Blake Callens"
-        },
-        {
-            "name": "Brian Hyder"
-        }
-    ],
-    "name": "pencilblue",
-    "description": "A full featured Node.js CMS and blogging platform (plugins, server cluster management, data-driven pages)",
-    "keywords": [
-        "cms",
-        "website",
-        "platform"
-    ],
-    "version": "0.6.0",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/pencilblue/pencilblue.git"
-    },
-    "dependencies": {
-        "async": "0.9.0",
-        "async-eventemitter": "0.2.2",
-        "cookies": "0.5.0",
-        "fakeredis": "0.3.0",
-        "formidable": "1.0.17",
-        "htmlencode": "0.0.4",
-        "http-status-codes": "^1.0.5",
-        "locale": "0.0.20",
-        "lodash": "^3.8.0",
-        "mongodb": "2.0.42",
-        "node-uuid": "1.4.3",
-        "node.extend": "1.1.3",
-        "nodemailer": "0.5.3",
-        "npm": "2.13.3",
-        "process": "0.11.2",
-        "redis": "0.12.1",
-        "sanitize-html": "1.1.7",
-        "semver": "4.3.3",
-        "winston": "0.9.0"
-    },
-    "devDependencies": {
-        "coveralls": "2.11.2",
-        "istanbul": "0.3.6",
-        "mocha": "2.1.0",
-        "mocha-lcov-reporter": "0.0.1",
-        "should": "5.0.1"
-    },
-    "main": "./pencilblue.js",
-    "engines": {
-        "node": ">= 0.11.0 <5"
-    },
-    "scripts": {
-        "start": "node pencilblue.js",
-        "test": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec --recursive"
-    },
-    "licenses": [
-        {
-            "type": "GNU GENERAL PUBLIC LICENSE Version 3",
-            "url": "http://www.gnu.org/licenses/gpl-3.0.html"
-        }
-    ],
-    "readme": "See README file",
-    "readmeFilename": "README.md",
-    "bugs": {
-        "url": "https://github.com/pencilblue/pencilblue/issues"
-    },
-    "_id": "pencilblue@0.6.0"
+    {
+      "name": "Brian Hyder"
+    }
+  ],
+  "name": "pencilblue",
+  "description": "A full featured Node.js CMS and blogging platform (plugins, server cluster management, data-driven pages)",
+  "keywords": [
+    "cms",
+    "website",
+    "platform"
+  ],
+  "version": "0.5.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pencilblue/pencilblue.git"
+  },
+  "dependencies": {
+    "async": "1.5.2",
+    "async-eventemitter": "0.2.2",
+    "cookies": "0.6.1",
+    "fakeredis": "1.0.2",
+    "formidable": "1.0.17",
+    "htmlencode": "0.0.4",
+    "http-status-codes": "^1.0.6",
+    "locale": "0.0.21",
+    "lodash": "^4.6.1",
+    "mongodb": "2.1.10",
+    "node-uuid": "1.4.7",
+    "node.extend": "1.1.5",
+    "nodemailer": "2.3.0",
+    "npm": "3.8.3",
+    "process": "0.11.2",
+    "redis": "2.2.3",
+    "sanitize-html": "1.11.3",
+    "semver": "5.1.0",
+    "winston": "2.2.0"
+  },
+  "devDependencies": {
+    "coveralls": "2.11.2",
+    "istanbul": "0.3.6",
+    "mocha": "2.1.0",
+    "mocha-lcov-reporter": "0.0.1",
+    "should": "5.0.1"
+  },
+  "main": "./pencilblue.js",
+  "engines": {
+    "node": ">= 0.11.0 <5"
+  },
+  "scripts": {
+    "start": "node pencilblue.js",
+    "test": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec --recursive"
+  },
+  "licenses": [
+    {
+      "type": "GNU GENERAL PUBLIC LICENSE Version 3",
+      "url": "http://www.gnu.org/licenses/gpl-3.0.html"
+    }
+  ],
+  "readme": "See README file",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/pencilblue/pencilblue/issues"
+  },
+  "_id": "pencilblue@0.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,74 +1,74 @@
 {
-  "author": {
-    "name": "PencilBlue, LLC",
-    "email": "info@pencilblue.com"
-  },
-  "contributors": [
-    {
-      "name": "Blake Callens"
+    "author": {
+        "name": "PencilBlue, LLC",
+        "email": "info@pencilblue.com"
     },
-    {
-      "name": "Brian Hyder"
-    }
-  ],
-  "name": "pencilblue",
-  "description": "A full featured Node.js CMS and blogging platform (plugins, server cluster management, data-driven pages)",
-  "keywords": [
-    "cms",
-    "website",
-    "platform"
-  ],
-  "version": "0.5.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/pencilblue/pencilblue.git"
-  },
-  "dependencies": {
-    "async": "1.5.2",
-    "async-eventemitter": "0.2.2",
-    "cookies": "0.6.1",
-    "fakeredis": "1.0.2",
-    "formidable": "1.0.17",
-    "htmlencode": "0.0.4",
-    "http-status-codes": "^1.0.6",
-    "locale": "0.0.21",
-    "lodash": "^4.6.1",
-    "mongodb": "2.1.10",
-    "node-uuid": "1.4.7",
-    "node.extend": "1.1.5",
-    "nodemailer": "2.3.0",
-    "npm": "3.8.3",
-    "process": "0.11.2",
-    "redis": "2.2.3",
-    "sanitize-html": "1.11.3",
-    "semver": "5.1.0",
-    "winston": "2.2.0"
-  },
-  "devDependencies": {
-    "coveralls": "2.11.2",
-    "istanbul": "0.3.6",
-    "mocha": "2.1.0",
-    "mocha-lcov-reporter": "0.0.1",
-    "should": "5.0.1"
-  },
-  "main": "./pencilblue.js",
-  "engines": {
-    "node": ">= 0.11.0 <5"
-  },
-  "scripts": {
-    "start": "node pencilblue.js",
-    "test": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec --recursive"
-  },
-  "licenses": [
-    {
-      "type": "GNU GENERAL PUBLIC LICENSE Version 3",
-      "url": "http://www.gnu.org/licenses/gpl-3.0.html"
-    }
-  ],
-  "readme": "See README file",
-  "readmeFilename": "README.md",
-  "bugs": {
-    "url": "https://github.com/pencilblue/pencilblue/issues"
-  },
-  "_id": "pencilblue@0.5.0"
+    "contributors": [
+        {
+            "name": "Blake Callens"
+        },
+        {
+            "name": "Brian Hyder"
+        }
+    ],
+    "name": "pencilblue",
+    "description": "A full featured Node.js CMS and blogging platform (plugins, server cluster management, data-driven pages)",
+    "keywords": [
+        "cms",
+        "website",
+        "platform"
+    ],
+    "version": "0.6.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/pencilblue/pencilblue.git"
+    },
+    "dependencies": {
+        "async": "1.5.2",
+        "async-eventemitter": "0.2.2",
+        "cookies": "0.6.1",
+        "fakeredis": "1.0.2",
+        "formidable": "1.0.17",
+        "htmlencode": "0.0.4",
+        "http-status-codes": "^1.0.6",
+        "locale": "0.0.21",
+        "lodash": "^4.6.1",
+        "mongodb": "2.1.10",
+        "node-uuid": "1.4.7",
+        "node.extend": "1.1.5",
+        "nodemailer": "2.3.0",
+        "npm": "3.8.3",
+        "process": "0.11.2",
+        "redis": "2.2.3",
+        "sanitize-html": "1.11.3",
+        "semver": "5.1.0",
+        "winston": "2.2.0"
+    },
+    "devDependencies": {
+        "coveralls": "2.11.2",
+        "istanbul": "0.3.6",
+        "mocha": "2.1.0",
+        "mocha-lcov-reporter": "0.0.1",
+        "should": "5.0.1"
+    },
+    "main": "./pencilblue.js",
+    "engines": {
+        "node": ">= 0.11.0 <5"
+    },
+    "scripts": {
+        "start": "node pencilblue.js",
+        "test": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec --recursive"
+    },
+    "licenses": [
+        {
+            "type": "GNU GENERAL PUBLIC LICENSE Version 3",
+            "url": "http://www.gnu.org/licenses/gpl-3.0.html"
+        }
+    ],
+    "readme": "See README file",
+    "readmeFilename": "README.md",
+    "bugs": {
+        "url": "https://github.com/pencilblue/pencilblue/issues"
+    },
+    "_id": "pencilblue@0.6.0"
 }


### PR DESCRIPTION
### Upgradeable Patches

The following dependencies can be fully updated, and passing all 357 tests:
The pull request includes an upgraded package.json:

async@1.5.2: Passed
cookies@0.6.1: Passed
fakeredis@1.0.2: Passed
http-status-codes@1.0.6: Passed
locale@0.0.21: Passed
lodash@4.6.1: Passed
mongodb@2.1.10: Passed
node-uuid@1.4.7: Passed
node.extend@1.1.5: Passed
nodemailer@2.3.0: Passed
npm@3.8.3: Passed
process@0.11.2: Passed
redis@2.2.3: Passed
sanitize-html@1.11.3: Passed
semver@5.1.0: Passed
winston@2.2.0: Passed

The tool we used to test is available here:
https://github.com/alt-code/ApiMonkey

### Redis

We also found several problems that will prevent upgrading to higher versions of redis.

Can upgrade to redis@2.2.3
357 passing (2s)

Anything above 2.2.4 fails

redis@2.2.5
  135 passing (464ms)
  7 failing
```
  1) SecurityService "before all" hook: Initialize the Environment with the default configuration:
     TypeError: undefined is not a function
      at RedisClient.install_stream_listeners (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/node_modules/redis/index.js:121:17)
      at new RedisClient (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/node_modules/redis/index.js:99:10)
      at Object.exports.createClient (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/node_modules/fakeredis/main.js:34:12)
      at Function.CacheModule.CacheFactory.createInstance (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/include/dao/cache.js:9:1528)
      at Function.CacheModule.CacheFactory.getInstance (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/include/dao/cache.js:9:713)
      at new PB (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/include/requirements.js:9:1226)
      at Context.<anonymous> (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/test/include/access_management_tests.js:16:14)
      at Hook.Runnable.run (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/node_modules/mocha/lib/runnable.js:218:15)
      at next (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/node_modules/mocha/lib/runner.js:259:10)
      at Immediate._onImmediate (/Users/gameweld/projects/ApiMonkey/js/undefined/dependencies/redis/2.2.5/node_modules/mocha/lib/runner.js:276:5)
      at processImmediate [as _immediateCallback] (timers.js:367:17)
      ....
```

redis@2.4.1
```
  1) SecurityService "before all" hook: Initialize the Environment with the default configuration:
     Uncaught Error: Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED
      at exports._errnoException (util.js:746:11)
      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1012:19)
```

redis@1.0.0: Passed
redis@2.0.0: Passed
redis@2.0.1: Passed
redis@2.1.0: Passed
redis@2.2.0: Passed
redis@2.2.1: Passed
redis@2.2.2: Passed
redis@2.2.3: Passed
redis@2.2.4: Failed
redis@2.2.5: Failed
redis@2.3.0: Failed
redis@2.3.1: Failed
redis@2.4.0: Failed
redis@2.4.1: Failed
redis@2.4.2: Failed
redis@2.5.0-1: Failed
redis@2.5.0: Failed
redis@2.5.1: Failed
redis@2.5.2: Failed
redis@2.5.3: Failed