### PR TITLE
Adds plugin bower dependency support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dependencies": {
         "async": "0.9.0",
         "async-eventemitter": "0.2.2",
+        "bower": "1.7.7",
         "cookies": "0.5.0",
         "fakeredis": "0.3.0",
         "formidable": "1.0.17",


### PR DESCRIPTION
Adds bower dependency.
Changes PluginService to check a plugin for bower dependencies listed under the details.json `bowerDependencies` property and to install those to the plugins _public/bower_components_ folder

Example:
```javascript
...
    "dependencies": {
        "xml2js": "~0.4.4"
    }
    "bowerDependencies": {
        "backbone": "1.3.2"
    }
}
```