### PR TITLE
Global Custom Object Types

### DIFF
--- a/plugins/pencilblue/controllers/actions/admin/content/objects/delete_object.js
+++ b/plugins/pencilblue/controllers/actions/admin/content/objects/delete_object.js
@@ -42,7 +42,7 @@ module.exports = function(pb) {
             return;
         }
 
-        var cos = new pb.CustomObjectService(self.site, true);
+        var cos = new pb.CustomObjectService(self.site, false);
         cos.loadById(vars.id, function(err, customObject) {
             if (util.isError(err)) {
                 return self.reqHandler.serveError(err);

--- a/plugins/pencilblue/controllers/actions/admin/content/objects/edit_object.js
+++ b/plugins/pencilblue/controllers/actions/admin/content/objects/edit_object.js
@@ -41,7 +41,7 @@ module.exports = function(pb) {
             return;
         }
 
-        var service = new pb.CustomObjectService(self.site, true);
+        var service = new pb.CustomObjectService(self.site, false);
         service.loadById(vars.id, function(err, custObj) {
             if (util.isError(err)) {
                 return cb(err);

--- a/plugins/pencilblue/controllers/actions/admin/content/objects/new_object.js
+++ b/plugins/pencilblue/controllers/actions/admin/content/objects/new_object.js
@@ -41,7 +41,7 @@ module.exports = function(pb) {
             return
         }
 
-        var service = new pb.CustomObjectService(self.site, true);
+        var service = new pb.CustomObjectService(self.site, false);
         service.loadTypeById(vars.type_id, function(err, customObjectType) {
             if(util.isError(err) || !util.isObject(customObjectType)) {
                 return cb({

--- a/plugins/pencilblue/controllers/actions/admin/content/objects/sort_objects.js
+++ b/plugins/pencilblue/controllers/actions/admin/content/objects/sort_objects.js
@@ -39,7 +39,7 @@ module.exports = function(pb) {
             });
         }
 
-        var service = new pb.CustomObjectService(self.site, true);
+        var service = new pb.CustomObjectService(self.site, false);
         service.loadTypeById(vars.type_id, function(err, customObjectType) {
             if(util.isError(err) || !util.isObject(customObjectType)) {
                 return cb({

--- a/plugins/pencilblue/controllers/actions/admin/content/objects/types/new_type.js
+++ b/plugins/pencilblue/controllers/actions/admin/content/objects/types/new_type.js
@@ -35,7 +35,7 @@ module.exports = function(pb) {
         var post = self.body;
         post.fields.name = {field_type: 'text'};
 
-        var service = new pb.CustomObjectService(self.site, true);
+        var service = new pb.CustomObjectService(self.site, false);
         service.saveType(post, function(err, result) {
             if(util.isError(err)) {
                 return cb({

--- a/plugins/pencilblue/controllers/admin/content/objects/manage_objects.js
+++ b/plugins/pencilblue/controllers/admin/content/objects/manage_objects.js
@@ -16,10 +16,10 @@
 */
 
 module.exports = function(pb) {
-    
+
     //pb dependencies
     var util = pb.util;
-    
+
     /**
      * Interface for managing objects
      * @class ManageObjects
@@ -40,7 +40,7 @@ module.exports = function(pb) {
             return this.reqHandler.serve404();
         }
 
-        var service = new pb.CustomObjectService(self.site, true);
+        var service = new pb.CustomObjectService(self.site, false);
         service.loadTypeById(vars.type_id, function(err, custObjType) {
             if (util.isError(err)) {
                 return self.serveError(err);

--- a/plugins/pencilblue/controllers/admin/content/objects/object_form.js
+++ b/plugins/pencilblue/controllers/admin/content/objects/object_form.js
@@ -19,10 +19,10 @@
 var async = require('async');
 
 module.exports = function(pb) {
-    
+
     //pb dependencies
     var util = pb.util;
-    
+
     /**
      * Interface for editing an object
      * @class ObjectFormController
@@ -96,7 +96,7 @@ module.exports = function(pb) {
 
     ObjectFormController.prototype.gatherData = function(vars, cb) {
         var self = this;
-        var cos = new pb.CustomObjectService(self.site, true);
+        var cos = new pb.CustomObjectService(self.site, false);
 
         var tasks = {
             tabs: function(callback) {
@@ -193,7 +193,7 @@ module.exports = function(pb) {
                     return;
                 }
 
-                //TODO: This is REALLY bad for large systems.  This needs to move 
+                //TODO: This is REALLY bad for large systems.  This needs to move
                 //to an API call (searchable and pagable)
                 var query = {
                     where: pb.DAO.ANYWHERE,

--- a/plugins/pencilblue/controllers/admin/content/objects/sort_objects.js
+++ b/plugins/pencilblue/controllers/admin/content/objects/sort_objects.js
@@ -16,10 +16,10 @@
 */
 
 module.exports = function(pb) {
-    
+
     //pb dependencies
     var util = pb.util;
-    
+
     /**
      * Interface for sorting objects
      * @class SortObjects
@@ -39,7 +39,7 @@ module.exports = function(pb) {
             return this.reqHandler.serve404();
         }
 
-        var service = new pb.CustomObjectService(self.site, true);
+        var service = new pb.CustomObjectService(self.site, false);
         service.loadTypeById(vars.type_id, function(err, objectType) {
             if(util.isError(err)) {
                 return self.reqHandler.serveError(err);

--- a/plugins/pencilblue/controllers/admin/content/objects/types/manage_types.js
+++ b/plugins/pencilblue/controllers/admin/content/objects/types/manage_types.js
@@ -16,10 +16,10 @@
 */
 
 module.exports = function(pb) {
-    
+
     //pb dependencies
     var util = pb.util;
-    
+
     /**
      * Interface for managing object types
      * @class ManageObjectTypes
@@ -32,34 +32,48 @@ module.exports = function(pb) {
     //statics
     var SUB_NAV_KEY = 'manage_object_types';
 
+    function handleError(err, obj){
+        if(err || !obj){
+            return [];
+        }
+        return obj;
+    }
+
     ManageObjectTypes.prototype.render = function(cb) {
         var self = this;
 
-        var service = new pb.CustomObjectService(self.site, true);
-        service.findTypes(function(err, custObjTypes) {
+        var service = new pb.CustomObjectService(self.site, false);
+        var globalService = new pb.CustomObjectService();
+        globalService.findTypes(function (err, globalObjTypes) {
+            globalObjTypes = handleError(err, globalObjTypes);
 
-            //none to manage
-            if(custObjTypes.length === 0) {
-                self.redirect('/admin/content/objects/types/new', cb);
-                return;
-            }
+            service.findTypes(function (err, custObjTypes) {
+                custObjTypes = handleError(err, custObjTypes);
 
-            //set listing of field types used by each of the custom object types
-            pb.CustomObjectService.setFieldTypesUsed(custObjTypes, self.ls);
+                custObjTypes = globalObjTypes.concat(custObjTypes);
+                //none to manage
+                if (custObjTypes.length === 0) {
+                    self.redirect('/admin/content/objects/types/new', cb);
+                    return;
+                }
 
-            //build out the angular controller
-            var angularObjects = pb.ClientJs.getAngularObjects(
-            {
-                navigation: pb.AdminNavigation.get(self.session, ['content', 'custom_objects'], self.ls, self.site),
-                pills: self.getAdminPills(SUB_NAV_KEY, self.ls, SUB_NAV_KEY),
-                objectTypes: custObjTypes
-            });
+                //set listing of field types used by each of the custom object types
+                pb.CustomObjectService.setFieldTypesUsed(custObjTypes, self.ls);
 
-            self.setPageName(self.ls.get('MANAGE_OBJECT_TYPES'));
-            self.ts.registerLocal('angular_objects', new pb.TemplateValue(angularObjects, false));
-            self.ts.load('admin/content/objects/types/manage_types', function(err, data) {
-                var result = '' + data;
-                cb({content: result});
+                //build out the angular controller
+                var angularObjects = pb.ClientJs.getAngularObjects(
+                    {
+                        navigation: pb.AdminNavigation.get(self.session, ['content', 'custom_objects'], self.ls, self.site),
+                        pills: self.getAdminPills(SUB_NAV_KEY, self.ls, SUB_NAV_KEY),
+                        objectTypes: custObjTypes
+                    });
+
+                self.setPageName(self.ls.get('MANAGE_OBJECT_TYPES'));
+                self.ts.registerLocal('angular_objects', new pb.TemplateValue(angularObjects, false));
+                self.ts.load('admin/content/objects/types/manage_types', function (err, data) {
+                    var result = '' + data;
+                    cb({content: result});
+                });
             });
         });
     };

--- a/plugins/pencilblue/controllers/admin/content/objects/types/type_form.js
+++ b/plugins/pencilblue/controllers/admin/content/objects/types/type_form.js
@@ -19,10 +19,10 @@
 var async = require('async');
 
 module.exports = function(pb) {
-    
+
     //pb dependencies
     var util = pb.util;
-    
+
     /**
      * Interface for creating and editing custom object types
      */
@@ -58,7 +58,7 @@ module.exports = function(pb) {
 
     TypeForm.prototype.gatherData = function(vars, cb) {
         var self = this;
-        var cos = new pb.CustomObjectService(self.site, true);
+        var cos = new pb.CustomObjectService(self.site, false);
 
         var tasks = {
             tabs: function(callback) {


### PR DESCRIPTION
Custom Object tweaks as discussed.  This allows for types to exist at the global scope, and be instanced on a site by site basis.  Mostly just changing onlyThisSite in the Custom Object Service to false instead of true, also required loading and merging of the global and site list for the manage type page.