### PR TITLE
Update to Git Ignore to Exclude Visual Studio Code IDE Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .jshintrc
 .project
 .idea
+.vscode
 public/media/
 public/docs/
 public/bower_components/


### PR DESCRIPTION
This request is to add ".vscode" to the Git Ignore settings.  This will allow working with Visual Studio Code, which has now been officially released, and not including the Visual Studio Code settings in the PencilBlue project.  For example, when attempting to debug in Visual Studio Code, one would create a launch.json file in the .vscode folder to control the Node.js debugger within Visual Studio Code.