### PR TITLE
Session check

### DIFF
--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -549,7 +549,9 @@ module.exports = function RequestHandlerModule(pb) {
             if (util.isError(err)) {
                 return self.serveError(err);
             }
-
+            if (!session) {
+                return self.serveError(new Error("The session object was not valid.  Unable to generate a session object based on request."));
+            }
             //set the session id when no session has started or the current one has
             //expired.
             var sc = Object.keys(cookies).length == 0;


### PR DESCRIPTION
This was the one fix that needed to be committed back to the platform that we found to be crashing the server.  There was a use case where session was not being returned from pb.session.open  We are not sure exactly how a user was managing to provide a request that would not allow this function to properly generate a session, however it was not being checked and was causing some errors for the server.  

Just committing back this fix, you might have more insight into why this might have been an issue or a more graceful/lower level change to fix this same issue.
