### PR TITLE
Fixed an order statement after a breaking change introduced with Mong…

### DIFF
--- a/plugins/pencilblue/controllers/section.js
+++ b/plugins/pencilblue/controllers/section.js
@@ -116,7 +116,7 @@ module.exports = function(pb) {
                 render: true,
                 where: {},
                 limit: self.contentSettings.articles_per_page || 5,
-                order: [{'publish_date': pb.DAO.DESC}, {'created': pb.DAO.DESC}]
+                order: {'publish_date': pb.DAO.DESC, 'created': pb.DAO.DESC}
             };
             pb.ContentObjectService.setPublishedClause(opts.where);
             self.service.getBySection(section, opts, function(err, content) {


### PR DESCRIPTION
Fixes #1082 - a breaking change in how the order is specified after the Mongo driver was updated, causing `MongoError: bad sort specification` when displaying a section (clicking on a section link).

There were two ways of doing so:
```
                order: {'publish_date': pb.DAO.DESC, 'created': pb.DAO.DESC}
```
or
```
                order: [['publish_date', pb.DAO.DESC], ['created', pb.DAO.DESC]]
```
I used the former for the sake of consistency with the rest of the order statements throughout the app.