### PR TITLE
Template Service Get

### DIFF
--- a/include/service/entities/template_service.js
+++ b/include/service/entities/template_service.js
@@ -236,10 +236,10 @@ module.exports = function(pb) {
     /**
      * returns the value associated with a registered local key(flag)
      *
-     * @method registerLocal
+     * @method getRegisteredLocal
      * @param {string} flag The flag name to map to the value when encountered in a
      * template.
-     * @return {callbackFunctionOrValue} the callback or the value that was assigned
+     * @return {*} the callback or the value that was assigned
      * to that local if the flag exists.  If not, it will return null
      */
     TemplateService.prototype.getRegisteredLocal = function(flag) {

--- a/include/service/entities/template_service.js
+++ b/include/service/entities/template_service.js
@@ -234,6 +234,20 @@ module.exports = function(pb) {
     };
 
     /**
+     * returns the value associated with a registered local key(flag)
+     *
+     * @method registerLocal
+     * @param {string} flag The flag name to map to the value when encountered in a
+     * template.
+     * @return {callbackFunctionOrValue} the callback or the value that was assigned
+     * to that local if the flag exists.  If not, it will return null
+     */
+    TemplateService.prototype.getRegisteredLocal = function(flag) {
+        return this.localCallbacks[flag] || null;
+    };
+
+
+    /**
      * When a flag is encountered that is not registered with the engine the
      * handler is called as a fail safe.  It is expected to return a string that
      * will be put in the place of the flag.


### PR DESCRIPTION
New Feature

- [ ] Unit tests created and pass
- [x] JS Docs have been updated

**Description:**
This provides a function to get the values that were registered via ts.registerLocal()  This allows for a value to be registered in one service, and then verified that it was registered in another service.

Use Case:  We registered a local in our controller.  We then called to a service to do some processing. We then wanted to see if that local was registered, if it was we would do one code flow, if not we would do another.


@pencilblue/owners

