### PR TITLE
Fixes #977 - Adds the ability to override the default sanitization rules

### DIFF
--- a/include/service/base_object_service.js
+++ b/include/service/base_object_service.js
@@ -192,6 +192,20 @@ module.exports = function(pb) {
     BaseObjectService.AFTER_DELETE = "afterDelete";
 
     /**
+     * @static
+     * @property ContentSanitizationRulesOverride
+     * @type {object|null}
+     */
+    BaseObjectService.ContentSanitizationRulesOverride = null;
+
+    /**
+     * @static
+     * @property DefaultSanitizationRulesOverride
+     * @type {object|null}
+     */
+    BaseObjectService.DefaultSanitizationRulesOverride = null;
+
+    /**
      * Retrieves the object type supported by the service
      * @method getType
      * @return {String} The object type supported
@@ -812,7 +826,7 @@ module.exports = function(pb) {
      * @return {Object}
      */
     BaseObjectService.getContentSanitizationRules = function() {
-        return {
+        return BaseObjectService.ContentSanitizationRulesOverride || {
             allowedTags: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div', 'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'img', 'u', 'span' ],
             allowedAttributes: {
                 a: [ 'href', 'name', 'target', 'class', 'align'],
@@ -841,13 +855,41 @@ module.exports = function(pb) {
     };
 
     /**
+     * Sets a system-wide override for the set of sanitization rules for content.  The function will throw if a non-object
+     * is passed.  NULL can be used to reset any override that is put into place.
+     * @static
+     * @method setDefaultSanitizationRules
+     * @param {object} rules
+     */
+    BaseObjectService.setContentSanitizationRules = function(rules) {
+        if (typeof rules !== 'object' || util.isArray(rules)) {
+            throw new Error('The content sanitization rules must be an object or null');
+        }
+        BaseObjectService.ContentSanitizationRulesOverride = rules;
+    };
+
+    /**
+     * Sets a system-wide override for the default set of sanitization rules.  The function will throw if a non-object
+     * is passed.  NULL can be used to reset any override that is put into place.
+     * @static
+     * @method setDefaultSanitizationRules
+     * @param {object} rules
+     */
+    BaseObjectService.setDefaultSanitizationRules = function(rules) {
+        if (typeof rules !== 'object' || util.isArray(rules)) {
+            throw new Error('The default sanitization rules must be an object or null');
+        }
+        BaseObjectService.DefaultSanitizationRulesOverride = rules;
+    };
+
+    /**
      * Retrieves the default sanitization rules for string fields.
      * @static
      * @method getDefaultSanitizationRules
      * @return {Object}
      */
     BaseObjectService.getDefaultSanitizationRules = function() {
-        return {
+        return BaseObjectService.DefaultSanitizationRulesOverride || {
             allowedTags: [],
             allowedAttributes: {}
         };

--- a/test/include/service/base_object_service_tests.js
+++ b/test/include/service/base_object_service_tests.js
@@ -61,6 +61,51 @@ describe('BaseObjectService', function() {
                 BaseObjectService.parseBoolean(val).should.eql(false);
             });
         });
-    })
+    });
 
+    describe('BaseObjectService.setDefaultSanitizationRules', function() {
+
+        ['0', false, 0, 1.1, 2.2, -1, undefined, []].forEach(function(val) {
+
+            it('should throw when passed a non-object, including array but not null', function() {
+                BaseObjectService.setDefaultSanitizationRules.bind(val).should.throwError();
+            });
+        });
+
+        it('should override the default set of rules when passed a valid object and reset when passed null', function() {
+
+            var overrides = {
+                allowedTags: ['div', 'h4']
+            };
+            var defaults = BaseObjectService.getDefaultSanitizationRules();
+            BaseObjectService.setDefaultSanitizationRules(overrides);
+            BaseObjectService.getDefaultSanitizationRules().should.eql(overrides);
+
+            BaseObjectService.setDefaultSanitizationRules(null);
+            BaseObjectService.getDefaultSanitizationRules().should.eql(defaults);
+        });
+    });
+
+    describe('BaseObjectService.setContentSanitizationRules', function() {
+
+        ['0', false, 0, 1.1, 2.2, -1, undefined, []].forEach(function(val) {
+
+            it('should throw when passed a non-object, including array but not null', function() {
+                BaseObjectService.setContentSanitizationRules.bind(val).should.throwError();
+            });
+        });
+
+        it('should override the default set of rules when passed a valid object and reset when passed null', function() {
+
+            var overrides = {
+                allowedTags: ['div', 'h4']
+            };
+            var defaults = BaseObjectService.getContentSanitizationRules();
+            BaseObjectService.setContentSanitizationRules(overrides);
+            BaseObjectService.getContentSanitizationRules().should.eql(overrides);
+
+            BaseObjectService.setContentSanitizationRules(null);
+            BaseObjectService.getContentSanitizationRules().should.eql(defaults);
+        });
+    });
 });


### PR DESCRIPTION
Fixes #877 

- [x] Unit tests created and pass
- [x] JS Docs have been updated

**Description:**
Adds the ability to override the sanitization rules for content fields as well as the generic fields that strip all HTML formatting.

@pencilblue/owners