### PR TITLE
Fixes #1103 Incorrect usage of reduce and a weird regex thing

### DIFF
--- a/include/dao/dao.js
+++ b/include/dao/dao.js
@@ -341,8 +341,8 @@ module.exports = function DAOModule(pb) {
 
             //log the result
             if(pb.config.db.query_logging){
-                var query = "DAO: %s %j FROM %s.%s WHERE %j";
-                var args = [options.count ? 'COUNT' : 'SELECT', select, self.dbName, entityType, where];
+                var query = "DAO: %s %j FROM %s.%s WHERE %s";
+                var args = [options.count ? 'COUNT' : 'SELECT', select, self.dbName, entityType, util.inspect(where, {breakLength: Infinity})];
                 if (typeof orderBy !== 'undefined') {
                     query += " ORDER BY %j";
                     args.push(orderBy);

--- a/include/service/entities/url_service.js
+++ b/include/service/entities/url_service.js
@@ -90,10 +90,8 @@ module.exports = function UrlServiceModule(pb) {
             url = url.substring(0, url.length - 1);
         }
         var pattern = "^\\/{0,1}" + util.escapeRegExp(url) + "\\/{0,1}$";
-
-        //execute search
         var where = {
-            url: new RegExp(pattern, 'g')
+            url: new RegExp(pattern, "i")
         };
         if (site !== undefined) {
             where[pb.SiteService.SITE_FIELD] = site;

--- a/include/service/entities/user_service.js
+++ b/include/service/entities/user_service.js
@@ -358,8 +358,8 @@ module.exports = function(pb) {
             var result = results === null;
             if (!result) {
 
-                Object.keys(results).reduce(function(actual, key) {
-                    return result || (results[key] > 0);
+                result = Object.keys(results).reduce(function (actual, key) {
+                    return actual || (results[key] > 0);
                 }, result);
             }
             cb(err, result);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "http-status-codes": "^1.0.6",
         "locale": "0.0.21",
         "lodash": "4.7.0",
-        "mongodb": "2.1.14",
+        "mongodb": "2.1.21",
         "node-uuid": "1.4.7",
         "node.extend": "1.1.5",
         "nodemailer": "0.7.1",

--- a/test/include/service/entities/url_service_tests.js
+++ b/test/include/service/entities/url_service_tests.js
@@ -1,0 +1,16 @@
+'use strict';
+
+//dependencies
+var should = require('should');
+var util = require('../../../../include/util.js');
+var TestHelpers = require('../../../test_helpers.js');
+
+describe('UrlService', function() {
+
+    TestHelpers.registerReset();
+
+    describe('UrlService.createSystemUrl', function() {
+
+        //TODO actually implement the tests
+    });
+});


### PR DESCRIPTION
Fixes #1103 

- [x] Unit tests created and pass
- [x] JS Docs have been updated

**Description:**
Corrects two issues.
1. An incorrect usage of "Array.reduce" caused a failure because its result was not being assigned.
2. The "g" (global) option does not seem to be supported by the mongo driver causing a weird failure.  Changing the matching strategy to case insensitive fixed the issue.  Seems weird because this worked before upgrading the driver.  


@pencilblue/owners

