### PR TITLE
Fixes #1106 - fixes a bug that did not cast the ObjectID to a string

### DIFF
--- a/plugins/pencilblue/controllers/actions/user/reset_password.js
+++ b/plugins/pencilblue/controllers/actions/user/reset_password.js
@@ -79,7 +79,7 @@ module.exports = function (pb) {
                 if (!data.user) {
                     self.formError(self.ls.get('INVALID_VERIFICATION'), '/user/login', cb);
                 }
-                self.passwordResetService.getSingle({where: {userId: data.user.id, verificationCode: self.query.code}}, callback);
+                self.passwordResetService.getSingle({where: {userId: data.user.id + '', verificationCode: self.query.code}}, callback);
             }],
             deletePasswordReset: ['user', 'passwordReset', function(callback, data) {
 


### PR DESCRIPTION
Fixes #

- [x] Unit tests created and pass
- [x] JS Docs have been updated

**Description:**
fixes a bug that did not cast the ObjectID to a string before using it in a  where clause


@pencilblue/owners

