### PR TITLE
Fixes wp_import not creating users

### DIFF
--- a/plugins/wp_import/services/wp_xml_parse.js
+++ b/plugins/wp_import/services/wp_xml_parse.js
@@ -203,6 +203,7 @@ module.exports = function WPXMLParseServiceModule(pb) {
                     users[index].email = 'user_' + util.uniqueId() + '@placeholder.com';
                     users[index].admin = pb.SecurityService.ACCESS_WRITER;
                     users[index].password = generatedPassword;
+                    users[index].locale = 'en-US';
 
                     self.service.add(users[index], function(err, result) {
                         if (util.isError(err)) {


### PR DESCRIPTION
The user service expects a locale to be present when adding a new user

@pencilblue/owners
