### PR TITLE
Fix the issue that can cause pencilblue crashing when there is an uns…

### DIFF
--- a/plugins/pencilblue/controllers/api/content/get_media_embed.js
+++ b/plugins/pencilblue/controllers/api/content/get_media_embed.js
@@ -85,7 +85,7 @@ module.exports = function(pb) {
             else if (!html) {
                 return cb({
                     code: 400,
-                    content: pb.BaseController.apiResponse(pb.BaseController.API_FAILURE, this.ls.g('generic.UNSUPPORTED_MEDIA'))
+                    content: pb.BaseController.apiResponse(pb.BaseController.API_FAILURE, self.ls.g('generic.UNSUPPORTED_MEDIA'))
                 });
             }
 


### PR DESCRIPTION
…upported media in the client editor

Fixes #

- [ ] Unit tests created and pass
- [ ] JS Docs have been updated

**Description:**
Fix the issue that can cause Pencilblue crashing when there is an unsupported media in the client editor

To reproduce issue:  
- Go to Pencilblue admin
- Go to pages
- Create a page
- Insert a none exist media (can be an image that deleted) to the editor

@pencilblue/owners
