### PR TITLE
docs: Fix simple typo, overriden -> overridden

### DIFF
--- a/controllers/api/api_action_controller.js
+++ b/controllers/api/api_action_controller.js
@@ -73,7 +73,7 @@ module.exports = function ApiActionControllerModule(pb) {
      * Provides the hash of all actions supported by this controller
      * @method getActions
      * @return {Object} An empty hash of actions since this is meant to be
-     * overriden.
+     * overridden.
      */
     ApiActionController.prototype.getActions = function() {
         return {};

--- a/controllers/form_controller.js
+++ b/controllers/form_controller.js
@@ -93,7 +93,7 @@ module.exports = function(pb) {
 
     /**
      * Called after the posted parameters have been received and parsed.  The
-     * function should be overriden in order to continue processing and render the
+     * function should be overridden in order to continue processing and render the
      * result of the request.  The default implementation echoes the received
      * parameters as JSON.
      * @method onPostParamsRetrieved

--- a/include/config.js
+++ b/include/config.js
@@ -24,7 +24,7 @@ var util    = require('./util.js');
 var winston = require('winston');
 
 /**
- * Default configuration.  The settings here should be overriden by taking the
+ * Default configuration.  The settings here should be overridden by taking the
  * example file "sample.config.js" and modifying it to override the properties
  * shown below.  In order to properly override the default configuration do the
  * following:
@@ -262,7 +262,7 @@ Configuration.getBaseConfig = function(multisite) {
             },
 
             //The default plugin.  Allows for the default plugin to be
-            //referenced from a single location.  The property can be overriden
+            //referenced from a single location.  The property can be overridden
             //but may have unexpected behavior.
             default: 'pencilblue'
         },

--- a/include/service/entities/plugins/plugin_dependency_service.js
+++ b/include/service/entities/plugins/plugin_dependency_service.js
@@ -51,7 +51,7 @@ module.exports = function (pb) {
      * @param {Function} cb
      */
     PluginDependencyService.prototype.hasDependencies = function(plugin, options, cb) {
-        throw new Error('This function must overriden by the inheriting prototype');
+        throw new Error('This function must overridden by the inheriting prototype');
     };
 
     /**
@@ -99,7 +99,7 @@ module.exports = function (pb) {
     };
 
     /**
-     * <b>NOTE: This function must be overriden by the inheriting prototype</b>
+     * <b>NOTE: This function must be overridden by the inheriting prototype</b>
      * Checks to see if the plugin dependency is already installed
      * @method isSatisfied
      * @param {object} context
@@ -109,7 +109,7 @@ module.exports = function (pb) {
      * @param {function} cb (Error, {{moduleName: string, success: boolean, validationFailures: Array}})
      */
     PluginDependencyService.prototype.isSatisfied = function(context, cb) {
-        throw new Error('This function must overriden by the inheriting prototype');
+        throw new Error('This function must overridden by the inheriting prototype');
     };
 
     /**
@@ -175,7 +175,7 @@ module.exports = function (pb) {
      * @param {function} cb (Error, Boolean)
      */
     PluginDependencyService.prototype._installAll = function(dependencies, options, cb) {
-        throw new Error('This function must overriden by the inheriting prototype');
+        throw new Error('This function must overridden by the inheriting prototype');
     };
 
     /**
@@ -187,7 +187,7 @@ module.exports = function (pb) {
      * @param {function} cb (Error, {logOutput: Array, logListener: function})
      */
     PluginDependencyService.prototype.configure = function(options, cb) {
-        throw new Error('This function must overriden by the inheriting prototype');
+        throw new Error('This function must overridden by the inheriting prototype');
     };
 
     /**
@@ -238,7 +238,7 @@ module.exports = function (pb) {
      * @return {string}
      */
     PluginDependencyService.prototype.getType = function() {
-        throw new Error('This function must overriden by the inheriting prototype');
+        throw new Error('This function must overridden by the inheriting prototype');
     };
 
     /**

--- a/include/service/entities/template_service.js
+++ b/include/service/entities/template_service.js
@@ -475,8 +475,8 @@ module.exports = function(pb) {
      * Called when a flag is encountered by the processing engine.  The function is
      * responsible for delegating out the responsibility of the flag to the
      * registered entity.  Some flags are handled by default (although they can
-     * always be overriden locally or globally).  The following flags are considered
-     * "baked in" and will be handled automatically unless overriden:
+     * always be overridden locally or globally).  The following flags are considered
+     * "baked in" and will be handled automatically unless overridden:
      * <ul>
      * <li>^loc_xyz^ - A localization flag.  When provided, the Localization
      * instance will have its "get" function called in an attempt to retrieve the

--- a/include/system/command/command_service.js
+++ b/include/system/command/command_service.js
@@ -262,7 +262,7 @@ module.exports = function CommandServiceModule(pb) {
      * becomes the command object.  Custom properties to be part of the command can
      * be added.  However, certain properties do have special meaning such as "id",
      * "to", "from", "timeout", "includeme".  These special properties may be
-     * overriden by this function or one it calls in order for the commands to
+     * overridden by this function or one it calls in order for the commands to
      * function properly.
      * @param {String} [options.id]
      * @param {Boolean} [options.ignoreme]

--- a/plugins/pencilblue/controllers/actions/admin/content/objects/types/edit_type.js
+++ b/plugins/pencilblue/controllers/actions/admin/content/objects/types/edit_type.js
@@ -52,7 +52,7 @@ module.exports = function(pb) {
 
             //TODO modify this approach to check for protected properties and allow
             //others.  Right now this will not allow additional fields if template
-            //is overriden.
+            //is overridden.
             var post = self.body;
             custObjType.name = post.name;
             custObjType.fields = post.fields;

--- a/plugins/sample/controllers/random_text_view.js
+++ b/plugins/sample/controllers/random_text_view.js
@@ -212,7 +212,7 @@ module.exports = function RandomTextViewControllerModule(pb) {
             //extension is implied and does not have to be specified.
             //While it appears that paths with forward '/' characters are
             //interpreted correctly on windows systems it is better to be safe an
-            //use the "path" module to join the parts correctly.  In this case we have overriden the "head.html"
+            //use the "path" module to join the parts correctly.  In this case we have overridden the "head.html"
             // template inside of templates/sample/index.html.  We want the template service to prioritize the "sample"
             // plugin's templates over the others so we explicitly tell the service that if you find a template
             // reference try the sample plugin first, then fall back to the others


### PR DESCRIPTION
There is a small typo in controllers/api/api_action_controller.js, controllers/form_controller.js, include/config.js, include/service/entities/plugins/plugin_dependency_service.js, include/service/entities/template_service.js, include/system/command/command_service.js, plugins/pencilblue/controllers/actions/admin/content/objects/types/edit_type.js, plugins/sample/controllers/random_text_view.js.

Should read `overridden` rather than `overriden`.

